### PR TITLE
Show install target on each row of the interactive skill picker

### DIFF
--- a/src/library_skills/cli.py
+++ b/src/library_skills/cli.py
@@ -69,6 +69,14 @@ class ProjectContext:
 
 
 @dataclass(frozen=True)
+class SkillTarget:
+    """A pairing of a discovered skill with the target it would be installed into."""
+
+    skill: Skill
+    target: InstallTarget
+
+
+@dataclass(frozen=True)
 class InstalledStatus:
     target: InstallTarget
     name: str
@@ -221,13 +229,23 @@ def _scan_json_payload(
     }
 
 
-def _select_skills_interactive(skills: list[Skill]) -> list[Skill]:
-    """Let the user interactively select which skills to install."""
+def _select_skills_interactive(
+    pairs: list[SkillTarget],
+) -> list[SkillTarget]:
+    """Let the user interactively select which skill/target pairs to install."""
     return _get_rich_toolkit().ask(
         "Select skills to install (press Space to select, Enter to confirm):",
         options=[
-            Option({"name": f"{skill.name} ({skill.package_name})", "value": skill})
-            for skill in skills
+            Option(
+                {
+                    "name": (
+                        f"{pair.skill.name} ({pair.skill.package_name}) "
+                        f"[{pair.target.name}]"
+                    ),
+                    "value": pair,
+                }
+            )
+            for pair in pairs
         ],
         allow_filtering=True,
         multiple=True,
@@ -378,25 +396,25 @@ def _select_installed_skills_interactive(
 
 def _install_selected(
     *,
-    skills: list[Skill],
-    targets: list[InstallTarget],
+    selections: list[SkillTarget],
     project_root: Path,
     copy: bool = False,
 ) -> int:
     installed_count = 0
-    for target in targets:
-        for skill in skills:
-            try:
-                dest = install_skill(skill, target.path, copy=copy)
-            except InstallError as e:
-                console.print(f"[error]Skipped {skill.name}:[/] {e}")
-                continue
-            method = "Copied" if copy else "Symlinked"
-            console.print(
-                f"{method}: [bold]{skill.name}[/bold] ({skill.package_name}) -> "
-                f"{_display_path(dest, project_root)}"
-            )
-            installed_count += 1
+    for selection in selections:
+        skill = selection.skill
+        target = selection.target
+        try:
+            dest = install_skill(skill, target.path, copy=copy)
+        except InstallError as e:
+            console.print(f"[error]Skipped {skill.name} ({target.name}):[/] {e}")
+            continue
+        method = "Copied" if copy else "Symlinked"
+        console.print(
+            f"{method}: [bold]{skill.name}[/bold] ({skill.package_name}) "
+            f"[{target.name}] -> {_display_path(dest, project_root)}"
+        )
+        installed_count += 1
     return installed_count
 
 
@@ -461,24 +479,29 @@ def _sync(
             if skill is not None:
                 install_skill(skill, status.target.path)
 
-    selected = _filter_installable_skills(
+    filtered_skills = _filter_installable_skills(
         candidate_skills,
         selected_names=selected_names,
         include_all=include_all,
     )
+    selected: list[SkillTarget] = [
+        SkillTarget(skill=skill, target=target)
+        for target in targets
+        for skill in filtered_skills
+    ]
     if not selected and not yes and not selected_names and not include_all:
-        new_skills = [
-            status.skill
+        new_pairs = [
+            SkillTarget(skill=status.skill, target=status.target)
             for status in visible_statuses
             if status.status == "new" and status.skill is not None
         ]
-        if new_skills:
-            selected = _select_skills_interactive(new_skills)
+        if new_pairs:
+            selected = _select_skills_interactive(new_pairs)
 
     if selected:
         console.print()
         installed_count = _install_selected(
-            skills=selected, targets=targets, project_root=context.project_root
+            selections=selected, project_root=context.project_root
         )
         console.print()
         console.print(f"Installed {installed_count} skill target(s).")
@@ -644,20 +667,30 @@ def install(
     targets = get_target_dirs(context.project_root, include_claude=include_claude)
 
     _print_warnings(result.warnings)
-    selected = _filter_installable_skills(
+    filtered_skills = _filter_installable_skills(
         skills,
         selected_names=selected_names or [],
         include_all=include_all,
     )
+    selected: list[SkillTarget] = [
+        SkillTarget(skill=skill, target=target)
+        for target in targets
+        for skill in filtered_skills
+    ]
     if not selected and not yes:
-        selected = _select_skills_interactive(skills)
+        pairs = [
+            SkillTarget(skill=skill, target=target)
+            for target in targets
+            for skill in skills
+        ]
+        selected = _select_skills_interactive(pairs)
 
     if not selected:
         console.print("No skills selected.")
         return
 
     installed_count = _install_selected(
-        skills=selected, targets=targets, project_root=context.project_root, copy=copy
+        selections=selected, project_root=context.project_root, copy=copy
     )
     console.print()
     console.print(f"Installed {installed_count} skill target(s).")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -478,7 +478,7 @@ def test_install_interactive_selection_installs_selected_skill(
     )
     monkeypatch.chdir(project)
 
-    with patch.object(cli, "_select_skills_interactive", lambda skills: skills):
+    with patch.object(cli, "_select_skills_interactive", lambda pairs: pairs):
         result = runner.invoke(app, ["install"])
 
     installed = project / ".agents" / "skills" / "demo-skill"
@@ -501,7 +501,7 @@ def test_default_command_interactive_selection_installs_selected_skill(
     )
     monkeypatch.chdir(project)
 
-    with patch.object(cli, "_select_skills_interactive", lambda skills: skills):
+    with patch.object(cli, "_select_skills_interactive", lambda pairs: pairs):
         result = runner.invoke(app)
 
     installed = project / ".agents" / "skills" / "demo-skill"
@@ -509,6 +509,34 @@ def test_default_command_interactive_selection_installs_selected_skill(
     assert "Installed 1 skill target(s)." in result.output
     assert installed.is_symlink()
     assert installed.resolve() == skill_dir.resolve()
+
+
+def test_claude_interactive_selection_installs_only_chosen_target(
+    tmp_path,
+    monkeypatch,
+):
+    project = write_project(tmp_path, dependencies=["demo-pkg>=1"])
+    site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
+    write_distribution_skill(
+        site_packages,
+        dist_name="demo-pkg",
+        package_dir="demo_pkg",
+        skill_name="demo-skill",
+    )
+    monkeypatch.chdir(project)
+
+    def _pick_claude_only(pairs):
+        return [pair for pair in pairs if pair.target.name == "claude-compatible"]
+
+    with patch.object(cli, "_select_skills_interactive", _pick_claude_only):
+        result = runner.invoke(app, ["--claude"])
+
+    universal = project / ".agents" / "skills" / "demo-skill"
+    claude = project / ".claude" / "skills" / "demo-skill"
+    assert result.exit_code == 0
+    assert "Installed 1 skill target(s)." in result.output
+    assert claude.is_symlink()
+    assert not universal.exists()
 
 
 def test_remove_interactive_selection_removes_selected_skill(tmp_path, monkeypatch):
@@ -597,6 +625,7 @@ def test_filter_installable_skills_skips_collisions(tmp_path):
 def test_select_helpers_use_rich_toolkit(monkeypatch, tmp_path):
     skill = make_cli_skill(tmp_path)
     target = cli.InstallTarget("universal", tmp_path / ".agents" / "skills")
+    pair = cli.SkillTarget(skill=skill, target=target)
     status = cli.InstalledStatus(
         target=target,
         name=skill.name,
@@ -606,9 +635,9 @@ def test_select_helpers_use_rich_toolkit(monkeypatch, tmp_path):
         status="up to date",
         skill=skill,
     )
-    monkeypatch.setattr(cli, "_get_rich_toolkit", lambda: FakeToolkit([skill]))
+    monkeypatch.setattr(cli, "_get_rich_toolkit", lambda: FakeToolkit([pair]))
 
-    assert cli._select_skills_interactive([skill]) == [skill]
+    assert cli._select_skills_interactive([pair]) == [pair]
 
     monkeypatch.setattr(cli, "_get_rich_toolkit", lambda: FakeToolkit([status]))
 
@@ -638,9 +667,10 @@ def test_install_selected_continues_after_install_error(tmp_path):
     skill = make_cli_skill(tmp_path)
     target = cli.InstallTarget("universal", tmp_path / ".agents" / "skills")
     (target.path / skill.name).mkdir(parents=True)
+    pair = cli.SkillTarget(skill=skill, target=target)
 
     assert (
-        cli._install_selected(skills=[skill], targets=[target], project_root=tmp_path)
+        cli._install_selected(selections=[pair], project_root=tmp_path)
         == 0
     )
 


### PR DESCRIPTION
Render one row per (skill, target) pair labeled `[universal]` / `[claude-compatible]` so users can pick targets independently. Selecting a row now installs only into that target. SkillTarget pairs are threaded through _install_selected instead of a blanket skills x targets product.

## Current look that confuses which FastAPI skill selected:
```
uvx library-skills --claude
Target Python environment: .venv
Site-packages: .venv/lib/python3.14/site-packages

 Target             Skill    Status  Path                    Source
 universal          fastapi  new     .agents/skills/fastapi  .venv/lib/python3.14/site-packages/fastapi/.agents/skills/fastapi
 claude-compatible  fastapi  new     .claude/skills/fastapi  .venv/lib/python3.14/site-packages/fastapi/.agents/skills/fastapi
Select skills to install (press Space to select, Enter to confirm):
Filter:

□ fastapi (fastapi)
□ fastapi (fastapi)
```

## New look
```
Target Python environment: .venv
Site-packages: .venv/lib/python3.14/site-packages

 Target             Skill    Status  Path                    Source
 universal          fastapi  new     .agents/skills/fastapi  .venv/lib/python3.14/site-packages/fastapi/.agents/skills/fastapi
 claude-compatible  fastapi  new     .claude/skills/fastapi  .venv/lib/python3.14/site-packages/fastapi/.agents/skills/fastapi
Select skills to install (press Space to select, Enter to confirm):
Filter:

□ fastapi (fastapi) [universal]
□ fastapi (fastapi) [claude-compatible]
```

## Note:

`uv cache clean library-skills` has to be run
