### PR TITLE
Remove $ to make commands easier to copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Supporting libraries (e.g. [FastAPI](https://fastapi.tiangolo.com), [Streamlit](
 In Python, you can install them with:
 
 ```console
-$ uvx library-skills
+uvx library-skills
 ```
 
 In JavaScript/TypeScript, you can install them with:
 
 ```console
-$ npx library-skills
+npx library-skills
 ```
 
 This will scan the dependencies for the current project, find the installed libraries, and ask you which of their skills you want to install in the project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,13 +44,13 @@ Supporting libraries (e.g. [FastAPI](https://fastapi.tiangolo.com), [Streamlit](
 In Python, you can install them with:
 
 ```console
-$ uvx library-skills
+uvx library-skills
 ```
 
 In JavaScript/TypeScript, you can install them with:
 
 ```console
-$ npx library-skills
+npx library-skills
 ```
 
 This will scan the dependencies for the current project, find the installed libraries, and ask you which of their skills you want to install in the project.

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -5,7 +5,7 @@ In your project directory, run:
 //// tab | Python uvx
 
 ```console
-$ uvx library-skills
+uvx library-skills
 ```
 
 ////
@@ -13,7 +13,7 @@ $ uvx library-skills
 //// tab | Node.js npx
 
 ```console
-$ npx library-skills
+npx library-skills
 ```
 
 ////
@@ -62,7 +62,7 @@ If you are using Claude Code, it doesn't support the `.agents` directory, only t
 //// tab | Python uvx
 
 ```console
-$ uvx library-skills --claude
+uvx library-skills --claude
 ```
 
 ////
@@ -70,7 +70,7 @@ $ uvx library-skills --claude
 //// tab | Node.js npx
 
 ```console
-$ npx library-skills --claude
+npx library-skills --claude
 ```
 
 ////
@@ -113,7 +113,7 @@ For automation or scripts, use `scan --json` to get the discovered skills as mac
 //// tab | Python uvx
 
 ```console
-$ uvx library-skills scan --json
+uvx library-skills scan --json
 ```
 
 ////
@@ -121,7 +121,7 @@ $ uvx library-skills scan --json
 //// tab | Node.js npx
 
 ```console
-$ npx library-skills scan --json
+npx library-skills scan --json
 ```
 
 ////
@@ -133,7 +133,7 @@ Use `list --json` to include the current installation status too:
 //// tab | Python uvx
 
 ```console
-$ uvx library-skills list --json
+uvx library-skills list --json
 ```
 
 ////
@@ -141,7 +141,7 @@ $ uvx library-skills list --json
 //// tab | Node.js npx
 
 ```console
-$ npx library-skills list --json
+npx library-skills list --json
 ```
 
 ////


### PR DESCRIPTION
Right now the literal $ is copied on both docs site and github