### PR TITLE
docs(use): add Eca (editor code assistant) to the list of agents

### DIFF
--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -54,6 +54,7 @@ This will work with AI Agents that support the `.agents` directory (most of them
 * Pi
 * Antigravity
 * OpenCode
+* Eca
 
 ### Claude Code
 


### PR DESCRIPTION
Adding the Open Source Eca tool to the list of agents that support the `.agents` standard.

Eca (editor code assistant) is Open Source and is a provider-independent agentic tool. I use it on a daily basis and really like it.

Details about Eca here: https://eca.dev/