### PR TITLE
🐛 Fix finding skills in editable installs in the Node.js version

### DIFF
--- a/ts/src/scanner.ts
+++ b/ts/src/scanner.ts
@@ -77,6 +77,7 @@ export function scanPythonDistributions(sitePackages: string): ScanResult {
 		if (found.skills.length === 0) {
 			const fallback = scanEditableDirectUrl({
 				distInfo,
+				sitePackages,
 				packageName: dist.name,
 				packageVersion: dist.version,
 				seenSkillDirs,
@@ -298,11 +299,13 @@ function isSkillFileRecord(installedPath: string): boolean {
 
 function scanEditableDirectUrl({
 	distInfo,
+	sitePackages,
 	packageName,
 	packageVersion,
 	seenSkillDirs,
 }: {
 	distInfo: string;
+	sitePackages?: string;
 	packageName: string;
 	packageVersion: string;
 	seenSkillDirs: Set<string>;
@@ -316,6 +319,9 @@ function scanEditableDirectUrl({
 	for (const skillMd of findSkillMarkdownFiles(sourceRoot)) {
 		const resolvedSkillMd = realpathOrResolve(skillMd);
 		if (!isRelativeTo(resolvedSkillMd, sourceRoot)) {
+			continue;
+		}
+		if (sitePackages && isRelativeTo(resolvedSkillMd, sitePackages)) {
 			continue;
 		}
 

--- a/ts/tests/library-skills.test.ts
+++ b/ts/tests/library-skills.test.ts
@@ -241,6 +241,40 @@ test("discovers editable skills from direct_url.json file URLs", () => {
   expect(result.skills.map((skill) => skill.name)).toEqual(["editable"]);
 });
 
+test("does not attribute nested site-packages skills to editable packages", () => {
+  const sourceRoot = tempDir();
+  const sitePackages = join(sourceRoot, ".venv", "lib", "python3.12", "site-packages");
+  const dependencySkill = writeSkill(
+    join(sitePackages, "fastapi", ".agents", "skills", "fastapi"),
+    "fastapi",
+    "FastAPI skill.",
+  );
+  const editableDist = writeDistribution({
+    sitePackages,
+    distInfoName: "aaa_editable_pkg-1.0.0.dist-info",
+    packageName: "aaa-editable-pkg",
+    version: "1.0.0",
+    records: [],
+  });
+  writeFileSync(
+    join(editableDist, "direct_url.json"),
+    JSON.stringify({ dir_info: { editable: true }, url: pathToFileURL(sourceRoot).href }),
+  );
+  writeDistribution({
+    sitePackages,
+    distInfoName: "fastapi-1.0.0.dist-info",
+    packageName: "fastapi",
+    version: "1.0.0",
+    records: [`${dependencySkill}/SKILL.md`.replace(`${sitePackages}/`, "") + ",,"],
+  });
+
+  const result = scanPythonDistributions(sitePackages);
+
+  expect(result.warnings).toEqual([]);
+  expect(result.skills.map((skill) => skill.name)).toEqual(["fastapi"]);
+  expect(result.skills[0]?.packageName).toBe("fastapi");
+});
+
 test("scanner helpers parse CSV and normalize package names", () => {
   expect(scannerTesting.isSkillFileRecord("pkg/.agents/skills/demo/SKILL.md")).toBe(true);
   expect(scannerTesting.isSkillFileRecord("pkg/.agents/other/demo/SKILL.md")).toBe(false);


### PR DESCRIPTION
## Pull Request

🐛 Fix finding skills in editable installs in the Node.js version

Equivalent to https://github.com/tiangolo/library-skills/pull/110 for the TypeScript code.

<!--
Please start with a GitHub Discussion.

Once a team member asks you to open a PR, create it and link the discussion here.

Obvious typo fixes can be made in a PR without starting a discussion.
-->

Discussion: <!-- Link to the GitHub Discussion -->

## Description

<!-- Write the description of your PR here -->

## AI Disclaimer

Codex with GPT 5.5 plus manual review.

<!-- If using AI, write here the prompt and model used -->

<details>
<summary>AI transcript</summary>

<!-- Paste here the entire AI transcript -->

</details>

## Checklist

- [ ] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
