### PR TITLE
🐛 Fix support for Python versions with tilde (`~`)

### DIFF
--- a/src/library_skills/deps.py
+++ b/src/library_skills/deps.py
@@ -103,7 +103,7 @@ def _extract_deps_from_specs(dep_specs: Sequence[object], deps: set[str]) -> Non
     for dep_spec in dep_specs:
         if not isinstance(dep_spec, str):
             continue
-        pkg_name = re.split(r"[>=<!\[;,\s]", dep_spec)[0].strip()
+        pkg_name = re.split(r"[~>=<!\[;,\s]", dep_spec)[0].strip()
         if pkg_name and not pkg_name.startswith("#"):
             deps.add(_normalize_package_name(pkg_name))
 

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -12,6 +12,7 @@ def test_get_python_top_level_deps_normalizes_required_and_optional_deps(tmp_pat
 [project]
 dependencies = [
     "Rich-Toolkit>=0.19",
+    "FastAPI~=0.115",
     "pydantic[email]>=2 ; python_version >= '3.10'",
 ]
 
@@ -25,6 +26,7 @@ dev = [
 
     assert get_python_top_level_deps(tmp_path) == {
         "rich-toolkit",
+        "fastapi",
         "pydantic",
         "pytest-cov",
     }

--- a/ts/src/deps.ts
+++ b/ts/src/deps.ts
@@ -97,7 +97,7 @@ function extractDepsFromSpecs(depSpecs: unknown[], deps: Set<string>): void {
     if (typeof depSpec !== "string") {
       continue;
     }
-    const packageName = depSpec.split(/[>=<![\];,\s]/)[0]?.trim();
+    const packageName = depSpec.split(/[~>=<![\];,\s]/)[0]?.trim();
     if (packageName && !packageName.startsWith("#")) {
       deps.add(normalizePackageName(packageName));
     }

--- a/ts/tests/library-skills.test.ts
+++ b/ts/tests/library-skills.test.ts
@@ -469,7 +469,7 @@ test("parses project dependency names from pyproject.toml", () => {
     join(project, "pyproject.toml"),
     [
       "[project]",
-      'dependencies = ["Example_Pkg>=1", "requests[security]; python_version >= \\"3.11\\""]',
+      'dependencies = ["Example_Pkg>=1", "FastAPI~=0.115", "requests[security]; python_version >= \\"3.11\\""]',
       "[project.optional-dependencies]",
       'dev = ["PyTest < 9"]',
       "",
@@ -477,7 +477,7 @@ test("parses project dependency names from pyproject.toml", () => {
   );
 
   expect(getPythonTopLevelDeps(project)).toEqual(
-    new Set(["example-pkg", "requests", "pytest"]),
+    new Set(["example-pkg", "fastapi", "requests", "pytest"]),
   );
 });
 


### PR DESCRIPTION
## Pull Request

🐛 Fix support for Python versions with tilde (`~`)

Reported in https://github.com/tiangolo/library-skills/pull/70#issuecomment-4758440435

<!--
Please start with a GitHub Discussion.

Once a team member asks you to open a PR, create it and link the discussion here.

Obvious typo fixes can be made in a PR without starting a discussion.
-->

Discussion: <!-- Link to the GitHub Discussion -->

## Description

<!-- Write the description of your PR here -->

## AI Disclaimer

Codex with GPT 5.5, review by hand.

<!-- If using AI, write here the prompt and model used -->

<details>
<summary>AI transcript</summary>

<!-- Paste here the entire AI transcript -->

</details>

## Checklist

- [ ] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
