### PR TITLE
♻️ Display the specific agent style (.agents, .claude) before removing

### DIFF
--- a/src/library_skills/cli.py
+++ b/src/library_skills/cli.py
@@ -169,6 +169,22 @@ def _display_path(path: Path | None, project_root: Path) -> str:
         return str(path)
 
 
+def _target_prompt_name(target: InstallTarget) -> str:
+    if target.name == "universal":
+        return "Agents (.agents/skills)"
+    if target.name == "claude-compatible":
+        return "Claude Code (.claude/skills)"
+    return target.name
+
+
+def _target_short_name(target: InstallTarget) -> str:
+    if target.name == "universal":
+        return "Agents"
+    if target.name == "claude-compatible":
+        return "Claude Code"
+    return target.name
+
+
 def _print_context(context: ProjectContext) -> None:
     rows = [("Project root", str(context.project_root))]
     if context.workspace is not None:
@@ -337,7 +353,7 @@ def _select_targets_interactive(
         options=[
             Option(
                 {
-                    "name": _display_path(target.path, project_root),
+                    "name": _target_prompt_name(target),
                     "value": target,
                 }
             )
@@ -555,7 +571,7 @@ def _select_installed_skills_interactive(
         options=[
             Option(
                 {
-                    "name": f"{status.name} [{status.target.name}]",
+                    "name": f"{status.name} [{_target_short_name(status.target)}]",
                     "value": status,
                 }
             )
@@ -616,7 +632,7 @@ def _select_statuses_interactive(
         options=[
             Option(
                 {
-                    "name": f"{status.name} [{status.target.name}]",
+                    "name": f"{status.name} [{_target_short_name(status.target)}]",
                     "value": status,
                 }
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1648,6 +1648,7 @@ def test_reconcile_helpers_cover_selection_skip_and_not_found(
         def __init__(self, label, *, options, **kwargs):
             assert "repair" in label
             assert kwargs["multiple"] is True
+            assert options[0]["name"] == "demo-skill [Agents]"
             self.options = options
             self.checked = set()
 
@@ -1685,6 +1686,10 @@ def test_select_targets_interactive_preselects_defaults(monkeypatch, tmp_path):
 
     class FakeMenu:
         def __init__(self, _label, *, options, **_kwargs):
+            assert [option["name"] for option in options] == [
+                "Agents (.agents/skills)",
+                "Claude Code (.claude/skills)",
+            ]
             self.options = options
             self.checked = set()
 
@@ -1762,6 +1767,19 @@ def test_display_path_prefers_project_relative_paths(tmp_path):
     )
     assert cli._display_path(outside, project) == str(outside)
     assert cli._display_path(None, project) == ""
+
+
+def test_target_prompt_labels_are_user_facing(tmp_path):
+    agents = cli.InstallTarget("universal", tmp_path / ".agents" / "skills")
+    claude = cli.InstallTarget("claude-compatible", tmp_path / ".claude" / "skills")
+    custom = cli.InstallTarget("custom", tmp_path / "custom")
+
+    assert cli._target_prompt_name(agents) == "Agents (.agents/skills)"
+    assert cli._target_prompt_name(claude) == "Claude Code (.claude/skills)"
+    assert cli._target_prompt_name(custom) == "custom"
+    assert cli._target_short_name(agents) == "Agents"
+    assert cli._target_short_name(claude) == "Claude Code"
+    assert cli._target_short_name(custom) == "custom"
 
 
 def test_main_module_invokes_cli_main():

--- a/ts/src/cli.ts
+++ b/ts/src/cli.ts
@@ -237,6 +237,26 @@ function displayPath(path: string | null | undefined, projectRoot: string): stri
 	return path;
 }
 
+function targetPromptName(target: InstallTarget): string {
+	if (target.name === "universal") {
+		return "Agents (.agents/skills)";
+	}
+	if (target.name === "claude-compatible") {
+		return "Claude Code (.claude/skills)";
+	}
+	return target.name;
+}
+
+function targetShortName(target: InstallTarget): string {
+	if (target.name === "universal") {
+		return "Agents";
+	}
+	if (target.name === "claude-compatible") {
+		return "Claude Code";
+	}
+	return target.name;
+}
+
 function printContext(context: ProjectContext): void {
 	output.printTitle("context");
 	const rows: Array<Record<string, string>> = [
@@ -520,7 +540,7 @@ async function selectTargetsInteractive({
 		message:
 			"Select installation targets (press Space to select, Enter to confirm):",
 		choices: getAllTargetDirs(projectRoot).map((target) => ({
-			name: displayPath(target.path, projectRoot),
+			name: targetPromptName(target),
 			value: target,
 			checked: defaultNames.has(target.name),
 		})),
@@ -572,7 +592,7 @@ async function selectInstalledSkillsInteractive(
 	return checkbox<InstalledStatus>({
 		message: "Select skills to remove (press Space to select, Enter to confirm):",
 		choices: removable.map((status) => ({
-			name: `${status.name} [${status.target.name}]`,
+			name: `${status.name} [${targetShortName(status.target)}]`,
 			value: status,
 		})),
 	});
@@ -631,7 +651,7 @@ async function selectStatusesInteractive(
 	return checkbox<InstalledStatus>({
 		message: `Select skills to ${action} (press Space to select, Enter to confirm):`,
 		choices: statuses.map((status) => ({
-			name: `${status.name} [${status.target.name}]`,
+			name: `${status.name} [${targetShortName(status.target)}]`,
 			value: status,
 			checked: true,
 		})),
@@ -1255,6 +1275,8 @@ export const testing = {
 	sync,
 	topLevelSkills,
 	displayPath,
+	targetPromptName,
+	targetShortName,
 	printTable: output.printTable,
 	printSummary: output.printSummary,
 };

--- a/ts/tests/library-skills.test.ts
+++ b/ts/tests/library-skills.test.ts
@@ -1627,6 +1627,42 @@ test("CLI helpers filter skills and classify installed statuses", () => {
   expect(cliTesting.displayPath(join(tempDir(), "outside"), root)).toMatch(/outside$/);
   expect(cliTesting.displayPath(null, root)).toBe("");
   expect(
+    cliTesting.targetPromptName({
+      name: "universal",
+      path: join(root, ".agents", "skills"),
+    }),
+  ).toBe("Agents (.agents/skills)");
+  expect(
+    cliTesting.targetPromptName({
+      name: "claude-compatible",
+      path: join(root, ".claude", "skills"),
+    }),
+  ).toBe("Claude Code (.claude/skills)");
+  expect(
+    cliTesting.targetPromptName({
+      name: "custom",
+      path: join(root, "custom"),
+    }),
+  ).toBe("custom");
+  expect(
+    cliTesting.targetShortName({
+      name: "universal",
+      path: join(root, ".agents", "skills"),
+    }),
+  ).toBe("Agents");
+  expect(
+    cliTesting.targetShortName({
+      name: "claude-compatible",
+      path: join(root, ".claude", "skills"),
+    }),
+  ).toBe("Claude Code");
+  expect(
+    cliTesting.targetShortName({
+      name: "custom",
+      path: join(root, "custom"),
+    }),
+  ).toBe("custom");
+  expect(
     cliTesting
       .repairableStatuses(statuses)
       .map((status) => status.name)
@@ -1664,6 +1700,7 @@ test("CLI reconcile helpers cover interactive selection and missing removals", a
   };
   vi.mocked(checkbox).mockImplementationOnce(async (prompt) => {
     expect(prompt.message).toContain("repair");
+    expect(prompt.choices[0].name).toBe("repair [Agents]");
     return [prompt.choices[0].value];
   });
   const { log } = mockConsole();
@@ -1875,6 +1912,10 @@ test("CLI interactive install can choose Claude targets", async () => {
   vi.mocked(checkbox)
     .mockImplementationOnce(async (prompt) => [prompt.choices[0].value])
     .mockImplementationOnce(async (prompt) => {
+      expect(prompt.choices.map((choice) => choice.name)).toEqual([
+        "Agents (.agents/skills)",
+        "Claude Code (.claude/skills)",
+      ]);
       expect(prompt.validate?.([])).toBe(
         "Please select at least one installation target.",
       );
@@ -1927,6 +1968,7 @@ test("CLI remove command covers selected, interactive, and empty removals", asyn
   expect(log).toHaveBeenCalledWith(expect.stringContaining("top-skill (universal)"));
 
   vi.mocked(checkbox).mockImplementationOnce(async (prompt) => {
+    expect(prompt.choices[0].name).toBe("transitive-skill [Agents]");
     const choice = prompt.choices[0].value;
     unlinkSync(choice.path);
     return [choice];


### PR DESCRIPTION
## Pull Request

♻️ Display the specific agent style (.agents, .claude) before removing

Inspired by this request in this PR: https://github.com/tiangolo/library-skills/pull/60

Although updated with the current shape of the code. E.g. don't show two skills to be selected, show only one, it's already letting the user select the target directory standard (Agents, Claude).

<!--
Please start with a GitHub Discussion.

Once a team member asks you to open a PR, create it and link the discussion here.

Obvious typo fixes can be made in a PR without starting a discussion.
-->

Discussion: <!-- Link to the GitHub Discussion -->

## Description

<!-- Write the description of your PR here -->

## AI Disclaimer

Codex with GPT 5.5

<!-- If using AI, write here the prompt and model used -->

<details>
<summary>AI transcript</summary>

<!-- Paste here the entire AI transcript -->

</details>

## Checklist

- [ ] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
