### PR TITLE
✨ Discover skills in an active VIRTUAL_ENV outside the project tree

### DIFF
--- a/src/library_skills/python_env.py
+++ b/src/library_skills/python_env.py
@@ -33,7 +33,10 @@ def find_venv(cwd: Path | None = None) -> Path | None:
     Resolution order:
     1. UV_PROJECT_ENVIRONMENT env var
     2. Nearest project .venv
-    3. VIRTUAL_ENV if it appears to belong to the project/user cwd
+    3. VIRTUAL_ENV, wherever it lives on disk. This covers tools (uv, venv,
+       virtualenv, conda, pyenv-virtualenv, Hatch, etc.) that manage
+       environments outside the project tree, since skills are installed into
+       the project root while the activated environment may live elsewhere.
     4. CONDA_PREFIX env var
     """
     cwd = cwd or Path.cwd()
@@ -54,18 +57,17 @@ def find_venv(cwd: Path | None = None) -> Path | None:
         venv = _venv_from_dot_venv(workspace.root)
         if venv is not None:
             return venv
-        return None
+    else:
+        for directory in [cwd, *cwd.parents]:
+            venv = _venv_from_dot_venv(directory)
+            if venv is not None:
+                return venv
 
-    for directory in [cwd, *cwd.parents]:
-        venv = _venv_from_dot_venv(directory)
-        if venv is not None:
-            return venv
-
-    # 3. VIRTUAL_ENV, but avoid uvx/tool environments outside the project tree
+    # 3. VIRTUAL_ENV, wherever it is located
     virtual_env = os.environ.get("VIRTUAL_ENV")
     if virtual_env:
         path = Path(virtual_env)
-        if (path / "pyvenv.cfg").is_file() and _is_relative_to(path, project_root):
+        if (path / "pyvenv.cfg").is_file():
             return path
 
     # 4. CONDA_PREFIX
@@ -108,14 +110,6 @@ def find_node_modules(cwd: Path | None = None) -> Path | None:
         if node_modules.is_dir():
             return node_modules
     return None
-
-
-def _is_relative_to(path: Path, parent: Path) -> bool:
-    try:
-        path.resolve().relative_to(parent.resolve())
-    except ValueError:
-        return False
-    return True
 
 
 def _venv_from_dot_venv(project_root: Path) -> Path | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1314,6 +1314,31 @@ def test_check_exits_non_zero_for_colliding_skill_names(tmp_path, monkeypatch):
     assert result.exit_code == 1
 
 
+def test_scan_uses_virtual_env_outside_project(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.delenv("UV_PROJECT_ENVIRONMENT", raising=False)
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+
+    outside_env = tmp_path / "hedge-managed-env"
+    site_packages = outside_env / "lib" / "python3.12" / "site-packages"
+    outside_env.mkdir(parents=True)
+    (outside_env / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding="utf-8")
+    write_distribution_skill(
+        site_packages,
+        dist_name="outside-pkg",
+        package_dir="outside_pkg",
+        skill_name="outside-skill",
+    )
+    monkeypatch.setenv("VIRTUAL_ENV", str(outside_env))
+
+    result = runner.invoke(app, ["scan"])
+
+    assert result.exit_code == 0
+    assert "outside-skill" in result.output
+
+
 def test_scan_without_target_environment_prints_warning(tmp_path, monkeypatch):
     project = tmp_path / "project"
     project.mkdir()

--- a/tests/test_python_env.py
+++ b/tests/test_python_env.py
@@ -112,6 +112,31 @@ members = ["packages/*"]
     assert find_venv(member) is None
 
 
+def test_find_venv_falls_back_to_virtual_env_in_workspace_without_root_environment(
+    monkeypatch,
+    tmp_path,
+):
+    workspace = tmp_path / "workspace"
+    member = workspace / "packages" / "api"
+    member.mkdir(parents=True)
+    (workspace / "pyproject.toml").write_text(
+        """
+[tool.uv.workspace]
+members = ["packages/*"]
+""",
+        encoding="utf-8",
+    )
+    (member / "pyproject.toml").write_text(
+        "[project]\nname = 'api'\nversion = '0.1.0'\n",
+        encoding="utf-8",
+    )
+    outside = make_venv(tmp_path / "hedge-managed-env")
+    clear_python_env_vars(monkeypatch)
+    monkeypatch.setenv("VIRTUAL_ENV", str(outside))
+
+    assert find_venv(member) == outside
+
+
 def test_find_venv_supports_pep_832_redirect_file(monkeypatch, tmp_path):
     project = tmp_path / "project"
     nested = project / "src" / "pkg"
@@ -170,14 +195,14 @@ def test_find_venv_ignores_invalid_pep_832_entries(monkeypatch, tmp_path):
     assert find_venv(nested) is None
 
 
-def test_find_venv_ignores_virtual_env_outside_project(monkeypatch, tmp_path):
+def test_find_venv_uses_virtual_env_outside_project(monkeypatch, tmp_path):
     project = tmp_path / "project"
     project.mkdir()
-    outside = make_venv(tmp_path / "tool-env")
+    outside = make_venv(tmp_path / "hatch-managed-env")
     clear_python_env_vars(monkeypatch)
     monkeypatch.setenv("VIRTUAL_ENV", str(outside))
 
-    assert find_venv(project) is None
+    assert find_venv(project) == outside
 
 
 def test_find_venv_uses_virtual_env_inside_project(monkeypatch, tmp_path):

--- a/ts/src/python-env.ts
+++ b/ts/src/python-env.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { findNodeWorkspace, findUvWorkspace } from "./workspace.js";
 
 export function findProjectRoot(cwd: string): string | null {
@@ -40,18 +40,21 @@ export function findVenv(cwd = process.cwd()): string | null {
   }
 
   if (workspace !== null) {
-    return venvFromDotVenv(workspace.root);
-  }
-
-  for (const directory of ancestors(cwd)) {
-    const venv = venvFromDotVenv(directory);
+    const venv = venvFromDotVenv(workspace.root);
     if (venv !== null) {
       return venv;
+    }
+  } else {
+    for (const directory of ancestors(cwd)) {
+      const venv = venvFromDotVenv(directory);
+      if (venv !== null) {
+        return venv;
+      }
     }
   }
 
   const virtualEnv = process.env["VIRTUAL_ENV"];
-  if (virtualEnv && isVenvDir(virtualEnv) && isRelativeTo(virtualEnv, projectRoot)) {
+  if (virtualEnv && isVenvDir(virtualEnv)) {
     return virtualEnv;
   }
 
@@ -141,15 +144,6 @@ function ancestors(start: string): string[] {
     directory = parent;
   }
   return result;
-}
-
-function isRelativeTo(path: string, parent: string): boolean {
-  const normalizedPath = resolve(path);
-  const normalizedParent = resolve(parent);
-  return (
-    normalizedPath === normalizedParent ||
-    normalizedPath.startsWith(`${normalizedParent}${sep}`)
-  );
 }
 
 function isFile(path: string): boolean {

--- a/ts/tests/library-skills.test.ts
+++ b/ts/tests/library-skills.test.ts
@@ -862,7 +862,7 @@ test("handles alternate and missing Python environment discovery paths", () => {
   const outside = tempDir();
   writeFileSync(join(outside, "pyvenv.cfg"), "");
   process.env = { ...originalEnv, VIRTUAL_ENV: outside };
-  expect(findVenv(nested)).toBeNull();
+  expect(findVenv(nested)).toBe(outside);
 
   const venv = join(project, "env");
   const windowsSitePackages = join(venv, "Lib", "site-packages");
@@ -893,6 +893,27 @@ test("handles alternate and missing Python environment discovery paths", () => {
   expect(getSitePackagesDir(tempDir())).toBeNull();
 });
 
+test("findVenv uses VIRTUAL_ENV wherever it is located, but project .venv wins", () => {
+  const project = tempDir();
+  const nested = join(project, "pkg");
+  mkdirSync(nested, { recursive: true });
+
+  const outside = tempDir();
+  writeFileSync(join(outside, "pyvenv.cfg"), "");
+  process.env = { ...originalEnv, VIRTUAL_ENV: outside };
+  expect(findVenv(nested)).toBe(outside);
+
+  const conda = tempDir();
+  process.env = { ...originalEnv, CONDA_PREFIX: conda };
+  expect(findVenv(project)).toBe(conda);
+
+  process.env = { ...originalEnv, VIRTUAL_ENV: outside };
+  const localVenv = join(project, ".venv");
+  mkdirSync(localVenv, { recursive: true });
+  writeFileSync(join(localVenv, "pyvenv.cfg"), "");
+  expect(findVenv(project)).toBe(localVenv);
+});
+
 test("honors UV_PROJECT_ENVIRONMENT before local .venv", () => {
   const project = tempDir();
   const uvEnv = join(project, ".custom-env");
@@ -916,6 +937,26 @@ test("resolves UV_PROJECT_ENVIRONMENT relative to uv workspace root", () => {
   process.env["UV_PROJECT_ENVIRONMENT"] = ".custom-env";
 
   expect(findVenv(api)).toBe(workspaceEnv);
+});
+
+test("falls back to VIRTUAL_ENV in a uv workspace without a root environment", () => {
+  const workspace = tempDir();
+  const member = join(workspace, "packages", "api");
+  mkdirSync(member, { recursive: true });
+  writeFileSync(
+    join(workspace, "pyproject.toml"),
+    ["[tool.uv.workspace]", 'members = ["packages/*"]', ""].join("\n"),
+  );
+  writeFileSync(
+    join(member, "pyproject.toml"),
+    ["[project]", 'name = "api"', 'version = "0.1.0"', ""].join("\n"),
+  );
+
+  const outside = tempDir();
+  writeFileSync(join(outside, "pyvenv.cfg"), "");
+  process.env = { ...originalEnv, VIRTUAL_ENV: outside };
+
+  expect(findVenv(member)).toBe(outside);
 });
 
 describe("installer", () => {
@@ -1121,6 +1162,25 @@ test("CLI scan defaults to top-level project dependencies", async () => {
   expect(log).toHaveBeenCalledWith(expect.stringContaining("node-skill"));
   expect(log).toHaveBeenCalledWith(expect.stringContaining("@scope/node-pkg"));
   expect(log).not.toHaveBeenCalledWith(expect.stringContaining("transitive-node-skill"));
+});
+
+test("CLI scan uses VIRTUAL_ENV pointing outside the project", async () => {
+  const project = tempDir();
+  process.chdir(project);
+  const outsideEnv = tempDir();
+  writeFileSync(join(outsideEnv, "pyvenv.cfg"), "");
+  const sitePackages = join(outsideEnv, "lib", "python3.12", "site-packages");
+  writePackageSkill({
+    sitePackages,
+    packageDir: "outside_pkg",
+    skillName: "outside-skill",
+    packageName: "outside-pkg",
+  });
+  process.env = { ...originalEnv, VIRTUAL_ENV: outsideEnv };
+  const { log } = mockConsole();
+
+  await createProgram().parseAsync(["node", "library-skills", "scan"]);
+  expect(log).toHaveBeenCalledWith(expect.stringContaining("outside-skill"));
 });
 
 test("CLI scan in uv workspace member uses workspace venv and member deps", async () => {


### PR DESCRIPTION
Hey there, greetings from Bavaria ;)

Disclaimer: Code was generated by Sonnet 5, reviewed by GPT 5.5.
Happy to discuss about the changes and adapt.


### Why

`library-skills` only searches for a target Python environment inside the current project tree. In practice, tools like **Hatch**, `pyenv-virtualenv`, Hatch, or a manually activated `virtualenv`/`venv` can activate an environment stored anywhere on disk (via the standard `VIRTUAL_ENV` variable), while the project's skills are always installed relative to the project root / current working directory. Previously, `find_venv`/`findVenv` silently rejected `VIRTUAL_ENV` unless it happened to live inside the project directory, so skills installed in these externally-managed environments were never discovered.

### What

- Widened the `VIRTUAL_ENV` resolution step in `find_venv` (Python) and `findVenv` (TypeScript) to accept the activated environment **regardless of where it lives on disk**, as long as it's a valid environment (`pyvenv.cfg` present). Removed the now-unused `_is_relative_to`/`isRelativeTo` restriction helpers.
- `UV_PROJECT_ENVIRONMENT` and the nearest project `.venv` (including PEP 832 redirect files) still take precedence over `VIRTUAL_ENV`, preserving the existing "prefer project-local signals" behavior — this is purely an additive relaxation of the `VIRTUAL_ENV` fallback, not a new flag or opt-in.
- Fixed a related uv-workspace bug found during review: when a uv workspace root had no valid `.venv`, resolution returned `None`/`null` immediately instead of falling through to check `VIRTUAL_ENV`/`CONDA_PREFIX`. Both implementations now fall through correctly.
- Updated/added tests in `tests/test_python_env.py`, `tests/test_cli.py`, and `ts/tests/library-skills.test.ts` covering: `VIRTUAL_ENV` outside the project now resolving, and the uv-workspace fallback regression case.

### Conclusion / research notes

Investigated whether this change could cause problems when the CLI is run via `uvx`:
- `uvx` does **not** set `VIRTUAL_ENV` to point at its own ephemeral, isolated tool environment — verified with a local probe package. So there's no risk of the tool scanning itself.
- If a user already has an unrelated venv activated in their shell (`VIRTUAL_ENV` set) and then runs `uvx library-skills` from a project with no local `.venv`/lock file, `uvx` simply inherits that `VIRTUAL_ENV` unchanged — the tool will now scan that unrelated environment instead of reporting "no environment found." This is the intended behavior for external venv managers and is inherent to trusting `VIRTUAL_ENV` at all (the same trust already extended to `CONDA_PREFIX`), not something `uvx` makes worse.

No new CLI flags; no documentation changes needed (the flag-based `--active` approach was tried and reverted in favor of this simpler, always-on fix).
