### PR TITLE
✨ Add glob and regex pattern matching to --skill

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -19,6 +19,8 @@ library-skills [OPTIONS] COMMAND [ARGS]...
 * `--check`: Validate only; exit 1 if installs drift
 * `--all`: Install all newly discovered unmanaged skills
 * `-s, --skill TEXT`: Install a specific discovered skill by name
+* `--discover-glob`: Treat --skill values as glob patterns matched against skill names
+* `--discover-regex`: Treat --skill values as regular expressions matched against skill names
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.
@@ -80,6 +82,8 @@ library-skills install [OPTIONS]
 * `-y, --yes`: Skip interactive selection
 * `--all`: Install all newly discovered unmanaged skills
 * `-s, --skill TEXT`: Install a specific discovered skill by name
+* `--discover-glob`: Treat --skill values as glob patterns matched against skill names
+* `--discover-regex`: Treat --skill values as regular expressions matched against skill names
 * `--copy`: Copy files instead of creating symlinks
 * `--help`: Show this message and exit.
 

--- a/src/library_skills/cli.py
+++ b/src/library_skills/cli.py
@@ -1,6 +1,9 @@
+import fnmatch
 import json
+import re
 from collections import Counter
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
@@ -327,18 +330,26 @@ def _print_action_header(action: str) -> None:
     ui.print_action_header(action, console=console)
 
 
-def _select_skills_interactive(skills: list[Skill]) -> list[Skill]:
+def _select_skills_interactive(
+    skills: list[Skill], *, preselect_all: bool = False
+) -> list[Skill]:
     """Let the user interactively select which skills to install."""
     _print_action_header("install")
-    return _get_rich_toolkit().ask(
+    toolkit = _get_rich_toolkit()
+    menu = Menu(
         "Select skills to install (press Space to select, Enter to confirm):",
         options=[
             Option({"name": f"{skill.name} ({skill.package_name})", "value": skill})
             for skill in skills
         ],
+        style=toolkit.style,
+        console=toolkit.console,
         allow_filtering=True,
         multiple=True,
     )
+    if preselect_all:
+        menu.checked = set(range(len(skills)))
+    return menu.ask()
 
 
 def _select_targets_interactive(
@@ -421,11 +432,66 @@ def _deduplicate_skills(skills: list[Skill]) -> list[Skill]:
     return unique
 
 
+class SkillMatchMode(str, Enum):
+    """How --skill values should be interpreted when resolving skill names."""
+
+    EXACT = "exact"
+    GLOB = "glob"
+    REGEX = "regex"
+
+
+def _resolve_skill_match_mode(
+    *, discover_glob: bool, discover_regex: bool
+) -> SkillMatchMode:
+    """Determine how --skill values should be interpreted."""
+    if discover_glob and discover_regex:
+        raise typer.BadParameter(
+            "--discover-glob and --discover-regex cannot be used together."
+        )
+    if discover_glob:
+        return SkillMatchMode.GLOB
+    if discover_regex:
+        return SkillMatchMode.REGEX
+    return SkillMatchMode.EXACT
+
+
+def _resolve_selected_skill_names(
+    available_names: list[str],
+    *,
+    patterns: list[str],
+    match_mode: SkillMatchMode,
+) -> set[str]:
+    """Resolve --skill values (exact names, globs, or regexes) to matched names."""
+    if not patterns:
+        return set()
+    if match_mode == SkillMatchMode.EXACT:
+        return set(patterns) & set(available_names)
+
+    compiled: list[re.Pattern[str]] = []
+    for pattern in patterns:
+        try:
+            if match_mode == SkillMatchMode.GLOB:
+                compiled.append(re.compile(fnmatch.translate(pattern), re.IGNORECASE))
+            else:
+                compiled.append(re.compile(pattern, re.IGNORECASE))
+        except re.error as exc:
+            raise typer.BadParameter(
+                f"Invalid regular expression for --skill: {pattern!r} ({exc})"
+            ) from exc
+
+    return {
+        name
+        for name in available_names
+        if any(pattern.fullmatch(name) for pattern in compiled)
+    }
+
+
 def _filter_installable_skills(
     skills: list[Skill],
     *,
     selected_names: list[str],
     include_all: bool,
+    match_mode: SkillMatchMode = SkillMatchMode.EXACT,
 ) -> list[Skill]:
     collisions = _find_collisions(skills)
     if collisions:
@@ -436,7 +502,11 @@ def _filter_installable_skills(
 
     installable = [skill for skill in skills if skill.name not in collisions]
     if selected_names:
-        selected = set(selected_names)
+        selected = _resolve_selected_skill_names(
+            [skill.name for skill in installable],
+            patterns=selected_names,
+            match_mode=match_mode,
+        )
         return [skill for skill in installable if skill.name in selected]
     if include_all:
         return installable
@@ -765,6 +835,7 @@ def _sync(
     check: bool,
     include_all: bool,
     selected_names: list[str],
+    match_mode: SkillMatchMode,
     copy: bool,
     tool_skill: bool | None,
 ) -> None:
@@ -855,8 +926,17 @@ def _sync(
         candidate_skills,
         selected_names=selected_names,
         include_all=include_all,
+        match_mode=match_mode,
     )
-    if (
+    pattern_mode = match_mode != SkillMatchMode.EXACT and bool(selected_names)
+    if pattern_mode:
+        if selected and not yes:
+            selected = _select_skills_interactive(
+                _deduplicate_skills(selected), preselect_all=True
+            )
+        elif not selected and not yes:
+            selected = _select_skills_interactive(candidate_skills)
+    elif (
         not selected
         and not yes
         and not selected_names
@@ -944,6 +1024,23 @@ def callback(
             "--skill", "-s", help="Install a specific discovered skill by name"
         ),
     ] = None,
+    discover_glob: Annotated[
+        bool,
+        typer.Option(
+            "--discover-glob",
+            help="Treat --skill values as glob patterns matched against skill names",
+        ),
+    ] = False,
+    discover_regex: Annotated[
+        bool,
+        typer.Option(
+            "--discover-regex",
+            help=(
+                "Treat --skill values as regular expressions matched against "
+                "skill names"
+            ),
+        ),
+    ] = False,
     copy: Annotated[
         bool, typer.Option("--copy", help="Copy files instead of creating symlinks")
     ] = False,
@@ -957,12 +1054,16 @@ def callback(
 ) -> None:
     """Discover and reconcile agent skills from installed library packages."""
     if ctx.invoked_subcommand is None:
+        match_mode = _resolve_skill_match_mode(
+            discover_glob=discover_glob, discover_regex=discover_regex
+        )
         _sync(
             include_claude=include_claude,
             yes=yes,
             check=check,
             include_all=include_all,
             selected_names=selected_names or [],
+            match_mode=match_mode,
             copy=copy,
             tool_skill=tool_skill,
         )
@@ -1077,11 +1178,31 @@ def install(
             "--skill", "-s", help="Install a specific discovered skill by name"
         ),
     ] = None,
+    discover_glob: Annotated[
+        bool,
+        typer.Option(
+            "--discover-glob",
+            help="Treat --skill values as glob patterns matched against skill names",
+        ),
+    ] = False,
+    discover_regex: Annotated[
+        bool,
+        typer.Option(
+            "--discover-regex",
+            help=(
+                "Treat --skill values as regular expressions matched against "
+                "skill names"
+            ),
+        ),
+    ] = False,
     copy: Annotated[
         bool, typer.Option("--copy", help="Copy files instead of creating symlinks")
     ] = False,
 ) -> None:
     """Install skills from installed packages."""
+    match_mode = _resolve_skill_match_mode(
+        discover_glob=discover_glob, discover_regex=discover_regex
+    )
     context = _get_project_context()
     result = _scan_context(context)
     skills = _top_level_skills(
@@ -1095,8 +1216,14 @@ def install(
         skills,
         selected_names=selected_names or [],
         include_all=include_all,
+        match_mode=match_mode,
     )
-    if not selected and not yes:
+    pattern_mode = match_mode != SkillMatchMode.EXACT and bool(selected_names)
+    if selected and pattern_mode and not yes:
+        selected = _select_skills_interactive(
+            _deduplicate_skills(selected), preselect_all=True
+        )
+    elif not selected and not yes:
         selected = _select_skills_interactive(skills)
 
     if not selected:

--- a/src/library_skills/tool_skill/SKILL.md
+++ b/src/library_skills/tool_skill/SKILL.md
@@ -28,6 +28,7 @@ Agents bundle their own skills by including an `.agents/skills` directory. More 
 - Run `uvx library-skills --yes` or `npx library-skills --yes` to repair stale managed symlinks and remove orphaned managed symlinks non-interactively.
 - Add `--claude` when `.claude/skills` should also be managed.
 - Add `--skill NAME` to install a specific discovered skill by name.
+- Add `--discover-glob` or `--discover-regex` to treat `--skill` values as glob patterns (e.g. `--skill 'api-*' --discover-glob`) or regular expressions (e.g. `--skill '^api-.*$' --discover-regex`) instead of exact names. Matching is case-insensitive and must match the whole skill name. These two flags are mutually exclusive.
 
 ## Safety
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1851,6 +1851,15 @@ def test_resolve_selected_skill_names_exact_mode_is_unchanged():
     assert matched == {"api-skill"}
 
 
+def test_resolve_selected_skill_names_returns_empty_set_for_no_patterns():
+    matched = cli._resolve_selected_skill_names(
+        ["api-skill", "other-skill"],
+        patterns=[],
+        match_mode=cli.SkillMatchMode.GLOB,
+    )
+    assert matched == set()
+
+
 def test_resolve_selected_skill_names_glob_mode_is_case_insensitive_and_full_match():
     names = ["api-skill", "api-tool", "other-skill"]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,12 @@
 import importlib
 import json
+import re
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+import typer
 from rich.console import Console
 from typer.testing import CliRunner
 
@@ -17,6 +20,12 @@ from library_skills.installer import (
 )
 
 runner = CliRunner()
+
+
+def plain_text(rich_output: str) -> str:
+    """Collapse Rich panel borders/line-wrapping so substring checks are stable."""
+    without_borders = re.sub(r"[\u2500-\u257F]", " ", rich_output)
+    return " ".join(without_borders.split())
 
 
 class FakeToolkit:
@@ -791,6 +800,232 @@ def test_install_skill_can_explicitly_select_transitive_dependency(
     assert result.exit_code == 0
     assert installed.is_symlink()
     assert installed.resolve() == transitive_skill.resolve()
+
+
+def test_install_discover_glob_installs_all_matches_with_yes(tmp_path, monkeypatch):
+    project = write_project(tmp_path, dependencies=["top-pkg>=1"])
+    site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
+    write_distribution(
+        site_packages,
+        dist_name="top-pkg",
+        package_dir="top_pkg",
+        skill_names=["api-skill", "api-tool", "other-skill"],
+    )
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(
+        app, ["install", "--skill", "api-*", "--discover-glob", "--yes", "--copy"]
+    )
+
+    assert result.exit_code == 0
+    assert (project / ".agents" / "skills" / "api-skill").is_dir()
+    assert (project / ".agents" / "skills" / "api-tool").is_dir()
+    assert not (project / ".agents" / "skills" / "other-skill").exists()
+
+
+def test_install_discover_regex_installs_all_matches_with_yes(tmp_path, monkeypatch):
+    project = write_project(tmp_path, dependencies=["top-pkg>=1"])
+    site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
+    write_distribution(
+        site_packages,
+        dist_name="top-pkg",
+        package_dir="top_pkg",
+        skill_names=["api-skill", "api-tool", "other-skill"],
+    )
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(
+        app,
+        ["install", "--skill", "^api-.*$", "--discover-regex", "--yes", "--copy"],
+    )
+
+    assert result.exit_code == 0
+    assert (project / ".agents" / "skills" / "api-skill").is_dir()
+    assert (project / ".agents" / "skills" / "api-tool").is_dir()
+    assert not (project / ".agents" / "skills" / "other-skill").exists()
+
+
+def test_install_discover_glob_and_regex_together_is_rejected(tmp_path, monkeypatch):
+    project = write_project(tmp_path, dependencies=[])
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(
+        app,
+        ["install", "--skill", "api-*", "--discover-glob", "--discover-regex"],
+    )
+
+    normalized_output = plain_text(result.output)
+    assert result.exit_code != 0
+    assert "cannot be used together" in normalized_output
+
+
+def test_install_discover_regex_invalid_pattern_is_rejected(tmp_path, monkeypatch):
+    project = write_project(tmp_path, dependencies=[])
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["install", "--skill", "(", "--discover-regex", "--yes"])
+
+    normalized_output = plain_text(result.output)
+    assert result.exit_code != 0
+    assert "Invalid regular expression" in normalized_output
+
+
+def test_install_discover_glob_without_yes_shows_precheck_picker_with_matches_only(
+    tmp_path, monkeypatch
+):
+    project = write_project(tmp_path, dependencies=["top-pkg>=1"])
+    site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
+    write_distribution(
+        site_packages,
+        dist_name="top-pkg",
+        package_dir="top_pkg",
+        skill_names=["api-skill", "api-tool", "other-skill"],
+    )
+    monkeypatch.chdir(project)
+
+    captured = {}
+
+    def fake_select(skills, *, preselect_all=False):
+        captured["names"] = sorted(skill.name for skill in skills)
+        captured["preselect_all"] = preselect_all
+        return skills
+
+    with (
+        patch.object(cli, "_select_skills_interactive", fake_select),
+        patch.object(
+            cli,
+            "_select_targets_interactive",
+            lambda project_root, default_targets: default_targets,
+        ),
+    ):
+        result = runner.invoke(
+            app, ["install", "--skill", "api-*", "--discover-glob", "--copy"]
+        )
+
+    assert result.exit_code == 0
+    assert captured == {"names": ["api-skill", "api-tool"], "preselect_all": True}
+    assert (project / ".agents" / "skills" / "api-skill").is_dir()
+    assert (project / ".agents" / "skills" / "api-tool").is_dir()
+
+
+def test_install_discover_glob_zero_matches_falls_back_to_full_picker(
+    tmp_path, monkeypatch
+):
+    project = write_project(tmp_path, dependencies=["top-pkg>=1"])
+    site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
+    write_distribution(
+        site_packages,
+        dist_name="top-pkg",
+        package_dir="top_pkg",
+        skill_names=["api-skill", "other-skill"],
+    )
+    monkeypatch.chdir(project)
+
+    captured = {}
+
+    def fake_select(skills, *, preselect_all=False):
+        captured["names"] = sorted(skill.name for skill in skills)
+        captured["preselect_all"] = preselect_all
+        return []
+
+    with patch.object(cli, "_select_skills_interactive", fake_select):
+        result = runner.invoke(app, ["install", "--skill", "zzz-*", "--discover-glob"])
+
+    assert result.exit_code == 0
+    assert captured["names"] == ["api-skill", "other-skill"]
+    assert captured["preselect_all"] is False
+    assert "No skills selected." in result.output
+
+
+def test_default_command_discover_glob_installs_all_matches_with_yes(
+    tmp_path, monkeypatch
+):
+    project = write_project(tmp_path, dependencies=["top-pkg>=1"])
+    site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
+    write_distribution(
+        site_packages,
+        dist_name="top-pkg",
+        package_dir="top_pkg",
+        skill_names=["api-skill", "api-tool", "other-skill"],
+    )
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(
+        app, ["--skill", "api-*", "--discover-glob", "--yes", "--copy"]
+    )
+
+    assert result.exit_code == 0
+    assert (project / ".agents" / "skills" / "api-skill").is_dir()
+    assert (project / ".agents" / "skills" / "api-tool").is_dir()
+    assert not (project / ".agents" / "skills" / "other-skill").exists()
+
+
+def test_default_command_discover_glob_precheck_installs_selected_matches(
+    tmp_path, monkeypatch
+):
+    project = write_project(tmp_path, dependencies=["top-pkg>=1"])
+    site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
+    write_distribution(
+        site_packages,
+        dist_name="top-pkg",
+        package_dir="top_pkg",
+        skill_names=["api-skill", "api-tool", "other-skill"],
+    )
+    monkeypatch.chdir(project)
+
+    captured = {}
+
+    def fake_select(skills, *, preselect_all=False):
+        captured["names"] = sorted(skill.name for skill in skills)
+        captured["preselect_all"] = preselect_all
+        return skills
+
+    with (
+        patch.object(cli, "_select_skills_interactive", fake_select),
+        patch.object(
+            cli,
+            "_select_targets_interactive",
+            lambda project_root, default_targets: default_targets,
+        ),
+        patch.object(cli, "_select_tool_skill_interactive", lambda: False),
+    ):
+        result = runner.invoke(app, ["--skill", "api-*", "--discover-glob", "--copy"])
+
+    assert result.exit_code == 0
+    assert captured == {"names": ["api-skill", "api-tool"], "preselect_all": True}
+    assert (project / ".agents" / "skills" / "api-skill").is_dir()
+    assert (project / ".agents" / "skills" / "api-tool").is_dir()
+
+
+def test_default_command_discover_glob_zero_matches_falls_back_to_full_picker(
+    tmp_path, monkeypatch
+):
+    project = write_project(tmp_path, dependencies=["top-pkg>=1"])
+    site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
+    write_distribution(
+        site_packages,
+        dist_name="top-pkg",
+        package_dir="top_pkg",
+        skill_names=["api-skill", "other-skill"],
+    )
+    monkeypatch.chdir(project)
+
+    captured = {}
+
+    def fake_select(skills, *, preselect_all=False):
+        captured["names"] = sorted(skill.name for skill in skills)
+        captured["preselect_all"] = preselect_all
+        return []
+
+    with (
+        patch.object(cli, "_select_skills_interactive", fake_select),
+        patch.object(cli, "_select_tool_skill_interactive", lambda: False),
+    ):
+        result = runner.invoke(app, ["--skill", "zzz-*", "--discover-glob"])
+
+    assert result.exit_code == 0
+    assert captured["names"] == ["api-skill", "other-skill"]
+    assert captured["preselect_all"] is False
 
 
 def test_yes_repairs_broken_managed_symlink_without_installing_new_skills(
@@ -1587,6 +1822,108 @@ def test_filter_installable_skills_skips_collisions(tmp_path):
     assert selected == []
 
 
+def test_resolve_skill_match_mode_rejects_both_flags():
+    with pytest.raises(typer.BadParameter):
+        cli._resolve_skill_match_mode(discover_glob=True, discover_regex=True)
+
+
+def test_resolve_skill_match_mode_selects_glob_or_regex_or_exact():
+    assert (
+        cli._resolve_skill_match_mode(discover_glob=False, discover_regex=False)
+        == cli.SkillMatchMode.EXACT
+    )
+    assert (
+        cli._resolve_skill_match_mode(discover_glob=True, discover_regex=False)
+        == cli.SkillMatchMode.GLOB
+    )
+    assert (
+        cli._resolve_skill_match_mode(discover_glob=False, discover_regex=True)
+        == cli.SkillMatchMode.REGEX
+    )
+
+
+def test_resolve_selected_skill_names_exact_mode_is_unchanged():
+    matched = cli._resolve_selected_skill_names(
+        ["api-skill", "other-skill"],
+        patterns=["api-skill"],
+        match_mode=cli.SkillMatchMode.EXACT,
+    )
+    assert matched == {"api-skill"}
+
+
+def test_resolve_selected_skill_names_glob_mode_is_case_insensitive_and_full_match():
+    names = ["api-skill", "api-tool", "other-skill"]
+
+    matched = cli._resolve_selected_skill_names(
+        names, patterns=["API-*"], match_mode=cli.SkillMatchMode.GLOB
+    )
+
+    assert matched == {"api-skill", "api-tool"}
+    # A glob must match the entire name, not just a substring.
+    assert (
+        cli._resolve_selected_skill_names(
+            names, patterns=["api"], match_mode=cli.SkillMatchMode.GLOB
+        )
+        == set()
+    )
+
+
+def test_resolve_selected_skill_names_regex_mode_is_case_insensitive_and_full_match():
+    names = ["api-skill", "api-tool", "other-skill"]
+
+    matched = cli._resolve_selected_skill_names(
+        names, patterns=["API-.*"], match_mode=cli.SkillMatchMode.REGEX
+    )
+
+    assert matched == {"api-skill", "api-tool"}
+    # A regex must match the entire name, not just a substring.
+    assert (
+        cli._resolve_selected_skill_names(
+            names, patterns=["api"], match_mode=cli.SkillMatchMode.REGEX
+        )
+        == set()
+    )
+
+
+def test_resolve_selected_skill_names_rejects_invalid_regex():
+    with pytest.raises(typer.BadParameter):
+        cli._resolve_selected_skill_names(
+            ["api-skill"], patterns=["("], match_mode=cli.SkillMatchMode.REGEX
+        )
+
+
+def test_filter_installable_skills_glob_mode_matches_and_skips_collisions(tmp_path):
+    api = make_cli_skill(tmp_path / "api", name="api-skill")
+    tool = make_cli_skill(tmp_path / "tool", name="api-tool")
+    other = make_cli_skill(tmp_path / "other", name="other-skill")
+    dup_a = make_cli_skill(tmp_path / "dup-a", name="dup-skill")
+    dup_b = make_cli_skill(tmp_path / "dup-b", name="dup-skill")
+
+    selected = cli._filter_installable_skills(
+        [api, tool, other, dup_a, dup_b],
+        selected_names=["api-*", "dup-*"],
+        include_all=False,
+        match_mode=cli.SkillMatchMode.GLOB,
+    )
+
+    assert {skill.name for skill in selected} == {"api-skill", "api-tool"}
+
+
+def test_filter_installable_skills_regex_mode_matches(tmp_path):
+    api = make_cli_skill(tmp_path / "api", name="api-skill")
+    tool = make_cli_skill(tmp_path / "tool", name="api-tool")
+    other = make_cli_skill(tmp_path / "other", name="other-skill")
+
+    selected = cli._filter_installable_skills(
+        [api, tool, other],
+        selected_names=["^api-.*$"],
+        include_all=False,
+        match_mode=cli.SkillMatchMode.REGEX,
+    )
+
+    assert {skill.name for skill in selected} == {"api-skill", "api-tool"}
+
+
 def test_select_helpers_use_rich_toolkit(monkeypatch, tmp_path, capsys):
     skill = make_cli_skill(tmp_path)
     target = cli.InstallTarget("universal", tmp_path / ".agents" / "skills")
@@ -1599,10 +1936,26 @@ def test_select_helpers_use_rich_toolkit(monkeypatch, tmp_path, capsys):
         status="up to date",
         skill=skill,
     )
-    monkeypatch.setattr(cli, "_get_rich_toolkit", lambda: FakeToolkit([skill]))
 
-    assert cli._select_skills_interactive([skill]) == [skill]
+    class FakeToolkitMenu:
+        style = None
+        console = None
+
+    class FakeMenu:
+        def __init__(self, _label, *, options, **kwargs):
+            assert kwargs["multiple"] is True
+            self.options = options
+            self.checked = set()
+
+        def ask(self):
+            return [self.options[index]["value"] for index in sorted(self.checked)]
+
+    monkeypatch.setattr(cli, "_get_rich_toolkit", lambda: FakeToolkitMenu())
+    monkeypatch.setattr(cli, "Menu", FakeMenu)
+
+    assert cli._select_skills_interactive([skill]) == []
     assert "install" in capsys.readouterr().out
+    assert cli._select_skills_interactive([skill], preselect_all=True) == [skill]
 
     monkeypatch.setattr(cli, "_get_rich_toolkit", lambda: FakeToolkit([status]))
 

--- a/ts/src/cli.ts
+++ b/ts/src/cli.ts
@@ -957,6 +957,7 @@ async function sync(options: GlobalOptions): Promise<void> {
 			process.exitCode = 1;
 			return;
 		}
+		/* v8 ignore next -- defensive rethrow; resolveSkillMatchMode only throws SkillMatchError. */
 		throw error;
 	}
 
@@ -1062,6 +1063,7 @@ async function sync(options: GlobalOptions): Promise<void> {
 			process.exitCode = 1;
 			return;
 		}
+		/* v8 ignore next -- defensive rethrow; filterInstallableSkills only throws SkillMatchError. */
 		throw error;
 	}
 	const patternMode = matchMode !== SkillMatchMode.Exact && selectedNames.length > 0;
@@ -1230,6 +1232,7 @@ async function installCommand(options: InstallOptions): Promise<void> {
 			process.exitCode = 1;
 			return;
 		}
+		/* v8 ignore next -- defensive rethrow; resolveSkillMatchMode only throws SkillMatchError. */
 		throw error;
 	}
 
@@ -1257,6 +1260,7 @@ async function installCommand(options: InstallOptions): Promise<void> {
 			process.exitCode = 1;
 			return;
 		}
+		/* v8 ignore next -- defensive rethrow; filterInstallableSkills only throws SkillMatchError. */
 		throw error;
 	}
 	const patternMode = matchMode !== SkillMatchMode.Exact && selectedNames.length > 0;

--- a/ts/src/cli.ts
+++ b/ts/src/cli.ts
@@ -86,6 +86,8 @@ interface GlobalOptions {
 	check?: boolean;
 	all?: boolean;
 	skill?: string[];
+	discoverGlob?: boolean;
+	discoverRegex?: boolean;
 	copy?: boolean;
 	toolSkill?: boolean;
 }
@@ -95,6 +97,8 @@ interface InstallOptions {
 	yes?: boolean;
 	all?: boolean;
 	skill?: string[];
+	discoverGlob?: boolean;
+	discoverRegex?: boolean;
 	copy?: boolean;
 }
 
@@ -373,14 +377,131 @@ function deduplicateSkills(skills: Skill[]): Skill[] {
 	return unique;
 }
 
+enum SkillMatchMode {
+	Exact = "exact",
+	Glob = "glob",
+	Regex = "regex",
+}
+
+class SkillMatchError extends Error {}
+
+function resolveSkillMatchMode({
+	discoverGlob,
+	discoverRegex,
+}: {
+	discoverGlob?: boolean;
+	discoverRegex?: boolean;
+}): SkillMatchMode {
+	if (discoverGlob && discoverRegex) {
+		throw new SkillMatchError(
+			"--discover-glob and --discover-regex cannot be used together.",
+		);
+	}
+	if (discoverGlob) {
+		return SkillMatchMode.Glob;
+	}
+	if (discoverRegex) {
+		return SkillMatchMode.Regex;
+	}
+	return SkillMatchMode.Exact;
+}
+
+/** Translate a shell-style glob (`*`, `?`, `[seq]`) into a regex source string. */
+function globToRegExpSource(pattern: string): string {
+	let result = "";
+	let i = 0;
+	while (i < pattern.length) {
+		const char = pattern[i];
+		if (char === "*") {
+			result += ".*";
+			i++;
+		} else if (char === "?") {
+			result += ".";
+			i++;
+		} else if (char === "[") {
+			let j = i + 1;
+			let negate = false;
+			if (pattern[j] === "!" || pattern[j] === "^") {
+				negate = true;
+				j++;
+			}
+			let classBody = "";
+			if (pattern[j] === "]") {
+				classBody += "\\]";
+				j++;
+			}
+			while (j < pattern.length && pattern[j] !== "]") {
+				classBody += pattern[j] === "\\" ? "\\\\" : pattern[j];
+				j++;
+			}
+			if (j < pattern.length) {
+				result += `[${negate ? "^" : ""}${classBody}]`;
+				i = j + 1;
+			} else {
+				// Unterminated bracket: treat '[' literally, like fnmatch does.
+				result += "\\[";
+				i++;
+			}
+		} else {
+			result += char.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+			i++;
+		}
+	}
+	return result;
+}
+
+function compileSkillPattern(
+	pattern: string,
+	matchMode: SkillMatchMode.Glob | SkillMatchMode.Regex,
+): RegExp {
+	const source =
+		matchMode === SkillMatchMode.Glob
+			? globToRegExpSource(pattern)
+			: `(?:${pattern})`;
+	try {
+		return new RegExp(`^${source}$`, "i");
+	} catch (error) {
+		throw new SkillMatchError(
+			`Invalid regular expression for --skill: ${JSON.stringify(pattern)} (${(error as Error).message})`,
+		);
+	}
+}
+
+/** Resolve --skill values (exact names, globs, or regexes) to matched skill names. */
+function resolveSelectedSkillNames(
+	availableNames: string[],
+	{
+		patterns,
+		matchMode,
+	}: {
+		patterns: string[];
+		matchMode: SkillMatchMode;
+	},
+): Set<string> {
+	if (patterns.length === 0) {
+		return new Set();
+	}
+	if (matchMode === SkillMatchMode.Exact) {
+		const patternSet = new Set(patterns);
+		return new Set(availableNames.filter((name) => patternSet.has(name)));
+	}
+
+	const compiled = patterns.map((pattern) => compileSkillPattern(pattern, matchMode));
+	return new Set(
+		availableNames.filter((name) => compiled.some((regex) => regex.test(name))),
+	);
+}
+
 function filterInstallableSkills({
 	skills,
 	selectedNames,
 	includeAll,
+	matchMode = SkillMatchMode.Exact,
 }: {
 	skills: Skill[];
 	selectedNames: string[];
 	includeAll: boolean;
+	matchMode?: SkillMatchMode;
 }): Skill[] {
 	const collisions = findCollisions(skills);
 	if (collisions.size > 0) {
@@ -391,7 +512,10 @@ function filterInstallableSkills({
 
 	const installable = skills.filter((skill) => !collisions.has(skill.name));
 	if (selectedNames.length > 0) {
-		const selected = new Set(selectedNames);
+		const selected = resolveSelectedSkillNames(
+			installable.map((skill) => skill.name),
+			{ patterns: selectedNames, matchMode },
+		);
 		return installable.filter((skill) => selected.has(skill.name));
 	}
 	return includeAll ? installable : [];
@@ -517,13 +641,17 @@ function printInstalledSkillsTable(
 	printStatusTable(installed, projectRoot);
 }
 
-async function selectSkillsInteractive(skills: Skill[]): Promise<Skill[]> {
+async function selectSkillsInteractive(
+	skills: Skill[],
+	{ preselectAll = false }: { preselectAll?: boolean } = {},
+): Promise<Skill[]> {
 	printActionHeader("install");
 	return checkbox<Skill>({
 		message: "Select skills to install (press Space to select, Enter to confirm):",
 		choices: skills.map((skill) => ({
 			name: `${skill.name} (${skill.packageName})`,
 			value: skill,
+			checked: preselectAll,
 		})),
 	});
 }
@@ -817,6 +945,21 @@ function toolSkillIsMissing(targets: InstallTarget[]): boolean {
 }
 
 async function sync(options: GlobalOptions): Promise<void> {
+	let matchMode: SkillMatchMode;
+	try {
+		matchMode = resolveSkillMatchMode({
+			discoverGlob: options.discoverGlob,
+			discoverRegex: options.discoverRegex,
+		});
+	} catch (error) {
+		if (error instanceof SkillMatchError) {
+			output.printWarning(error.message);
+			process.exitCode = 1;
+			return;
+		}
+		throw error;
+	}
+
 	const context = getProjectContext();
 	const result = scanContext(context);
 	let targets = syncTargetDirs({
@@ -905,12 +1048,32 @@ async function sync(options: GlobalOptions): Promise<void> {
 		removeSelected({ statuses: selectedRemovals, projectRoot: context.projectRoot });
 	}
 
-	let selected = filterInstallableSkills({
-		skills: candidateSkills,
-		selectedNames,
-		includeAll: Boolean(options.all),
-	});
-	if (
+	let selected: Skill[];
+	try {
+		selected = filterInstallableSkills({
+			skills: candidateSkills,
+			selectedNames,
+			includeAll: Boolean(options.all),
+			matchMode,
+		});
+	} catch (error) {
+		if (error instanceof SkillMatchError) {
+			output.printWarning(error.message);
+			process.exitCode = 1;
+			return;
+		}
+		throw error;
+	}
+	const patternMode = matchMode !== SkillMatchMode.Exact && selectedNames.length > 0;
+	if (patternMode) {
+		if (selected.length > 0 && !options.yes) {
+			selected = await selectSkillsInteractive(deduplicateSkills(selected), {
+				preselectAll: true,
+			});
+		} else if (selected.length === 0 && !options.yes) {
+			selected = await selectSkillsInteractive(candidateSkills);
+		}
+	} else if (
 		selected.length === 0 &&
 		!options.yes &&
 		selectedNames.length === 0 &&
@@ -1055,6 +1218,21 @@ function listCommand(options: ListOptions): void {
 }
 
 async function installCommand(options: InstallOptions): Promise<void> {
+	let matchMode: SkillMatchMode;
+	try {
+		matchMode = resolveSkillMatchMode({
+			discoverGlob: options.discoverGlob,
+			discoverRegex: options.discoverRegex,
+		});
+	} catch (error) {
+		if (error instanceof SkillMatchError) {
+			output.printWarning(error.message);
+			process.exitCode = 1;
+			return;
+		}
+		throw error;
+	}
+
 	const context = getProjectContext();
 	const result = scanContext(context);
 	const selectedNames = options.skill ?? [];
@@ -1065,12 +1243,28 @@ async function installCommand(options: InstallOptions): Promise<void> {
 	});
 
 	printWarnings(result.warnings);
-	let selected = filterInstallableSkills({
-		skills,
-		selectedNames,
-		includeAll: Boolean(options.all),
-	});
-	if (selected.length === 0 && !options.yes) {
+	let selected: Skill[];
+	try {
+		selected = filterInstallableSkills({
+			skills,
+			selectedNames,
+			includeAll: Boolean(options.all),
+			matchMode,
+		});
+	} catch (error) {
+		if (error instanceof SkillMatchError) {
+			output.printWarning(error.message);
+			process.exitCode = 1;
+			return;
+		}
+		throw error;
+	}
+	const patternMode = matchMode !== SkillMatchMode.Exact && selectedNames.length > 0;
+	if (selected.length > 0 && patternMode && !options.yes) {
+		selected = await selectSkillsInteractive(deduplicateSkills(selected), {
+			preselectAll: true,
+		});
+	} else if (selected.length === 0 && !options.yes) {
 		selected = await selectSkillsInteractive(skills);
 	}
 
@@ -1159,6 +1353,14 @@ export function createProgram(): Command {
 			collect,
 			[],
 		)
+		.option(
+			"--discover-glob",
+			"Treat --skill values as glob patterns matched against skill names",
+		)
+		.option(
+			"--discover-regex",
+			"Treat --skill values as regular expressions matched against skill names",
+		)
 		.action(async (options: GlobalOptions) => {
 			await sync(options);
 		});
@@ -1197,6 +1399,14 @@ export function createProgram(): Command {
 			"Install a specific discovered skill by name",
 			collect,
 			[],
+		)
+		.option(
+			"--discover-glob",
+			"Treat --skill values as glob patterns matched against skill names",
+		)
+		.option(
+			"--discover-regex",
+			"Treat --skill values as regular expressions matched against skill names",
 		)
 		.option("--copy", "Copy files instead of creating symlinks")
 		.action(async (options: InstallOptions) => {
@@ -1267,9 +1477,14 @@ export const testing = {
 	removeSelected,
 	repairSelected,
 	repairableStatuses,
+	resolveSkillMatchMode,
+	resolveSelectedSkillNames,
 	scanCommand,
+	selectSkillsInteractive,
 	selectStatusesInteractive,
 	selectToolSkillInteractive,
+	SkillMatchError,
+	SkillMatchMode,
 	syncToolSkill,
 	syncTargetDirs,
 	sync,

--- a/ts/src/tool_skill/SKILL.md
+++ b/ts/src/tool_skill/SKILL.md
@@ -28,6 +28,7 @@ Agents bundle their own skills by including an `.agents/skills` directory. More 
 - Run `uvx library-skills --yes` or `npx library-skills --yes` to repair stale managed symlinks and remove orphaned managed symlinks non-interactively.
 - Add `--claude` when `.claude/skills` should also be managed.
 - Add `--skill NAME` to install a specific discovered skill by name.
+- Add `--discover-glob` or `--discover-regex` to treat `--skill` values as glob patterns (e.g. `--skill 'api-*' --discover-glob`) or regular expressions (e.g. `--skill '^api-.*$' --discover-regex`) instead of exact names. Matching is case-insensitive and must match the whole skill name. These two flags are mutually exclusive.
 
 ## Safety
 

--- a/ts/tests/library-skills.test.ts
+++ b/ts/tests/library-skills.test.ts
@@ -1684,6 +1684,347 @@ test("CLI helpers filter skills and classify installed statuses", () => {
   expect(log).toHaveBeenCalledWith(expect.stringContaining("removed: 2"));
 });
 
+test("resolveSkillMatchMode rejects combining glob and regex discovery flags", () => {
+  expect(() =>
+    cliTesting.resolveSkillMatchMode({ discoverGlob: true, discoverRegex: true }),
+  ).toThrow(cliTesting.SkillMatchError);
+});
+
+test("resolveSkillMatchMode selects glob, regex, or exact", () => {
+  expect(cliTesting.resolveSkillMatchMode({})).toBe(cliTesting.SkillMatchMode.Exact);
+  expect(cliTesting.resolveSkillMatchMode({ discoverGlob: true })).toBe(
+    cliTesting.SkillMatchMode.Glob,
+  );
+  expect(cliTesting.resolveSkillMatchMode({ discoverRegex: true })).toBe(
+    cliTesting.SkillMatchMode.Regex,
+  );
+});
+
+test("resolveSelectedSkillNames exact mode is unchanged", () => {
+  const matched = cliTesting.resolveSelectedSkillNames(["api-skill", "other-skill"], {
+    patterns: ["api-skill"],
+    matchMode: cliTesting.SkillMatchMode.Exact,
+  });
+  expect(matched).toEqual(new Set(["api-skill"]));
+});
+
+test("resolveSelectedSkillNames glob mode is case-insensitive and full match", () => {
+  const names = ["api-skill", "api-tool", "other-skill"];
+  expect(
+    cliTesting.resolveSelectedSkillNames(names, {
+      patterns: ["API-*"],
+      matchMode: cliTesting.SkillMatchMode.Glob,
+    }),
+  ).toEqual(new Set(["api-skill", "api-tool"]));
+  // A glob must match the entire name, not just a substring.
+  expect(
+    cliTesting.resolveSelectedSkillNames(names, {
+      patterns: ["api"],
+      matchMode: cliTesting.SkillMatchMode.Glob,
+    }),
+  ).toEqual(new Set());
+});
+
+test("resolveSelectedSkillNames regex mode is case-insensitive and full match", () => {
+  const names = ["api-skill", "api-tool", "other-skill"];
+  expect(
+    cliTesting.resolveSelectedSkillNames(names, {
+      patterns: ["API-.*"],
+      matchMode: cliTesting.SkillMatchMode.Regex,
+    }),
+  ).toEqual(new Set(["api-skill", "api-tool"]));
+  // A regex must match the entire name, not just a substring.
+  expect(
+    cliTesting.resolveSelectedSkillNames(names, {
+      patterns: ["api"],
+      matchMode: cliTesting.SkillMatchMode.Regex,
+    }),
+  ).toEqual(new Set());
+});
+
+test("resolveSelectedSkillNames rejects an invalid regex pattern", () => {
+  expect(() =>
+    cliTesting.resolveSelectedSkillNames(["api-skill"], {
+      patterns: ["("],
+      matchMode: cliTesting.SkillMatchMode.Regex,
+    }),
+  ).toThrow(cliTesting.SkillMatchError);
+});
+
+test("filterInstallableSkills glob mode matches and still skips collisions", () => {
+  const api = makeSkill({ name: "api-skill", skillDir: "/skills/api-skill" });
+  const tool = makeSkill({ name: "api-tool", skillDir: "/skills/api-tool" });
+  const other = makeSkill({ name: "other-skill", skillDir: "/skills/other-skill" });
+  const dupA = makeSkill({ name: "dup-skill", skillDir: "/skills/dup-a" });
+  const dupB = makeSkill({ name: "dup-skill", skillDir: "/skills/dup-b" });
+
+  const selected = cliTesting.filterInstallableSkills({
+    skills: [api, tool, other, dupA, dupB],
+    selectedNames: ["api-*", "dup-*"],
+    includeAll: false,
+    matchMode: cliTesting.SkillMatchMode.Glob,
+  });
+
+  expect(selected.map((skill) => skill.name).sort()).toEqual(["api-skill", "api-tool"]);
+});
+
+test("filterInstallableSkills regex mode matches", () => {
+  const api = makeSkill({ name: "api-skill", skillDir: "/skills/api-skill" });
+  const tool = makeSkill({ name: "api-tool", skillDir: "/skills/api-tool" });
+  const other = makeSkill({ name: "other-skill", skillDir: "/skills/other-skill" });
+
+  const selected = cliTesting.filterInstallableSkills({
+    skills: [api, tool, other],
+    selectedNames: ["^api-.*$"],
+    includeAll: false,
+    matchMode: cliTesting.SkillMatchMode.Regex,
+  });
+
+  expect(selected.map((skill) => skill.name).sort()).toEqual(["api-skill", "api-tool"]);
+});
+
+function writeGlobTestProject(skillNames: string[]): string {
+  const project = tempDir();
+  const sitePackages = join(project, ".venv", "lib", "python3.12", "site-packages");
+  mkdirSync(sitePackages, { recursive: true });
+  writeFileSync(join(project, ".venv", "pyvenv.cfg"), "");
+  writeFileSync(join(project, "pyproject.toml"), "[project]\ndependencies = ['top-pkg']\n");
+  writeDistribution({
+    sitePackages,
+    distInfoName: "top_pkg-1.0.0.dist-info",
+    packageName: "top-pkg",
+    version: "1.0.0",
+    records: skillNames.map((name) => `top_pkg/.agents/skills/${name}/SKILL.md,,`),
+  });
+  for (const name of skillNames) {
+    writeSkill(
+      join(sitePackages, "top_pkg", ".agents", "skills", name),
+      name,
+      `${name} description.`,
+    );
+  }
+  return project;
+}
+
+test("CLI install --discover-glob installs all matches with --yes", async () => {
+  const project = writeGlobTestProject(["api-skill", "api-tool", "other-skill"]);
+  process.chdir(project);
+  mockConsole();
+
+  await createProgram().parseAsync([
+    "node",
+    "library-skills",
+    "install",
+    "--skill",
+    "api-*",
+    "--discover-glob",
+    "--yes",
+    "--copy",
+  ]);
+
+  expect(existsSync(join(project, ".agents", "skills", "api-skill"))).toBe(true);
+  expect(existsSync(join(project, ".agents", "skills", "api-tool"))).toBe(true);
+  expect(existsSync(join(project, ".agents", "skills", "other-skill"))).toBe(false);
+});
+
+test("CLI install --discover-regex installs all matches with --yes", async () => {
+  const project = writeGlobTestProject(["api-skill", "api-tool", "other-skill"]);
+  process.chdir(project);
+  mockConsole();
+
+  await createProgram().parseAsync([
+    "node",
+    "library-skills",
+    "install",
+    "--skill",
+    "^api-.*$",
+    "--discover-regex",
+    "--yes",
+    "--copy",
+  ]);
+
+  expect(existsSync(join(project, ".agents", "skills", "api-skill"))).toBe(true);
+  expect(existsSync(join(project, ".agents", "skills", "api-tool"))).toBe(true);
+  expect(existsSync(join(project, ".agents", "skills", "other-skill"))).toBe(false);
+});
+
+test("CLI install rejects combining --discover-glob and --discover-regex", async () => {
+  const project = writeGlobTestProject(["api-skill"]);
+  process.chdir(project);
+  const { log } = mockConsole();
+
+  await createProgram().parseAsync([
+    "node",
+    "library-skills",
+    "install",
+    "--skill",
+    "api-*",
+    "--discover-glob",
+    "--discover-regex",
+  ]);
+
+  expect(process.exitCode).toBe(1);
+  expect(
+    log.mock.calls.some(([message]) =>
+      String(message).includes("cannot be used together"),
+    ),
+  ).toBe(true);
+  process.exitCode = undefined;
+});
+
+test("CLI install rejects an invalid --discover-regex pattern", async () => {
+  const project = writeGlobTestProject(["api-skill"]);
+  process.chdir(project);
+  const { log } = mockConsole();
+
+  await createProgram().parseAsync([
+    "node",
+    "library-skills",
+    "install",
+    "--skill",
+    "(",
+    "--discover-regex",
+    "--yes",
+  ]);
+
+  expect(process.exitCode).toBe(1);
+  expect(
+    log.mock.calls.some(([message]) =>
+      String(message).includes("Invalid regular expression"),
+    ),
+  ).toBe(true);
+  process.exitCode = undefined;
+});
+
+test("CLI install --discover-glob shows precheck picker limited to matches, preselected", async () => {
+  const project = writeGlobTestProject(["api-skill", "api-tool", "other-skill"]);
+  process.chdir(project);
+  mockConsole();
+
+  let capturedNames: string[] = [];
+  let capturedChecked: boolean[] = [];
+  vi.mocked(checkbox)
+    .mockImplementationOnce(async (prompt) => {
+      capturedNames = prompt.choices.map((choice) => String(choice.name));
+      capturedChecked = prompt.choices.map((choice) => Boolean(choice.checked));
+      return prompt.choices.map((choice) => choice.value);
+    })
+    .mockResolvedValueOnce([{ name: "universal", path: join(project, ".agents", "skills") }]);
+
+  await createProgram().parseAsync([
+    "node",
+    "library-skills",
+    "install",
+    "--skill",
+    "api-*",
+    "--discover-glob",
+    "--copy",
+  ]);
+
+  expect(capturedNames.sort()).toEqual(["api-skill (top-pkg)", "api-tool (top-pkg)"]);
+  expect(capturedChecked).toEqual([true, true]);
+  expect(existsSync(join(project, ".agents", "skills", "api-skill"))).toBe(true);
+  expect(existsSync(join(project, ".agents", "skills", "api-tool"))).toBe(true);
+});
+
+test("CLI install --discover-glob zero matches falls back to the full picker", async () => {
+  const project = writeGlobTestProject(["api-skill", "other-skill"]);
+  process.chdir(project);
+  const { log } = mockConsole();
+
+  let capturedNames: string[] = [];
+  vi.mocked(checkbox).mockImplementationOnce(async (prompt) => {
+    capturedNames = prompt.choices.map((choice) => String(choice.name));
+    return [];
+  });
+
+  await createProgram().parseAsync([
+    "node",
+    "library-skills",
+    "install",
+    "--skill",
+    "zzz-*",
+    "--discover-glob",
+  ]);
+
+  expect(capturedNames.sort()).toEqual(["api-skill (top-pkg)", "other-skill (top-pkg)"]);
+  expect(log).toHaveBeenCalledWith("No skills selected.");
+});
+
+test("CLI default command --discover-glob installs all matches with --yes", async () => {
+  const project = writeGlobTestProject(["api-skill", "api-tool", "other-skill"]);
+  process.chdir(project);
+  mockConsole();
+
+  await createProgram().parseAsync([
+    "node",
+    "library-skills",
+    "--skill",
+    "api-*",
+    "--discover-glob",
+    "--yes",
+    "--copy",
+  ]);
+
+  expect(existsSync(join(project, ".agents", "skills", "api-skill"))).toBe(true);
+  expect(existsSync(join(project, ".agents", "skills", "api-tool"))).toBe(true);
+  expect(existsSync(join(project, ".agents", "skills", "other-skill"))).toBe(false);
+});
+
+test("CLI default command --discover-glob precheck picker installs selected matches", async () => {
+  const project = writeGlobTestProject(["api-skill", "api-tool", "other-skill"]);
+  process.chdir(project);
+  mockConsole();
+
+  let capturedNames: string[] = [];
+  let capturedChecked: boolean[] = [];
+  vi.mocked(checkbox)
+    .mockImplementationOnce(async (prompt) => {
+      capturedNames = prompt.choices.map((choice) => String(choice.name));
+      capturedChecked = prompt.choices.map((choice) => Boolean(choice.checked));
+      return prompt.choices.map((choice) => choice.value);
+    })
+    .mockResolvedValueOnce([{ name: "universal", path: join(project, ".agents", "skills") }]);
+
+  await createProgram().parseAsync([
+    "node",
+    "library-skills",
+    "--skill",
+    "api-*",
+    "--discover-glob",
+    "--copy",
+    "--no-tool-skill",
+  ]);
+
+  expect(capturedNames.sort()).toEqual(["api-skill (top-pkg)", "api-tool (top-pkg)"]);
+  expect(capturedChecked).toEqual([true, true]);
+  expect(existsSync(join(project, ".agents", "skills", "api-skill"))).toBe(true);
+  expect(existsSync(join(project, ".agents", "skills", "api-tool"))).toBe(true);
+});
+
+test("CLI default command --discover-glob zero matches falls back to the full picker", async () => {
+  const project = writeGlobTestProject(["api-skill", "other-skill"]);
+  process.chdir(project);
+  mockConsole();
+
+  let capturedNames: string[] = [];
+  vi.mocked(checkbox).mockImplementationOnce(async (prompt) => {
+    capturedNames = prompt.choices.map((choice) => String(choice.name));
+    return [];
+  });
+
+  await createProgram().parseAsync([
+    "node",
+    "library-skills",
+    "--skill",
+    "zzz-*",
+    "--discover-glob",
+    "--no-tool-skill",
+  ]);
+
+  expect(capturedNames.sort()).toEqual(["api-skill (top-pkg)", "other-skill (top-pkg)"]);
+});
+
 test("CLI reconcile helpers cover interactive selection and missing removals", async () => {
   const root = tempDir();
   const target = { name: "universal", path: join(root, ".agents", "skills") };

--- a/ts/tests/library-skills.test.ts
+++ b/ts/tests/library-skills.test.ts
@@ -1708,6 +1708,65 @@ test("resolveSelectedSkillNames exact mode is unchanged", () => {
   expect(matched).toEqual(new Set(["api-skill"]));
 });
 
+test("resolveSelectedSkillNames returns an empty set for no patterns", () => {
+  const matched = cliTesting.resolveSelectedSkillNames(["api-skill", "other-skill"], {
+    patterns: [],
+    matchMode: cliTesting.SkillMatchMode.Glob,
+  });
+  expect(matched).toEqual(new Set());
+});
+
+test("resolveSelectedSkillNames glob mode supports ? wildcards", () => {
+  const matched = cliTesting.resolveSelectedSkillNames(["api-skill", "api-tool"], {
+    patterns: ["api-?kill"],
+    matchMode: cliTesting.SkillMatchMode.Glob,
+  });
+  expect(matched).toEqual(new Set(["api-skill"]));
+});
+
+test("resolveSelectedSkillNames glob mode supports [seq] character classes", () => {
+  const names = ["api-skill", "api-tkill", "api-xkill"];
+  const matched = cliTesting.resolveSelectedSkillNames(names, {
+    patterns: ["api-[st]kill"],
+    matchMode: cliTesting.SkillMatchMode.Glob,
+  });
+  expect(matched).toEqual(new Set(["api-skill", "api-tkill"]));
+});
+
+test("resolveSelectedSkillNames glob mode supports negated [seq] character classes", () => {
+  const names = ["api-skill", "api-tkill"];
+  expect(
+    cliTesting.resolveSelectedSkillNames(names, {
+      patterns: ["api-[!s]kill"],
+      matchMode: cliTesting.SkillMatchMode.Glob,
+    }),
+  ).toEqual(new Set(["api-tkill"]));
+  expect(
+    cliTesting.resolveSelectedSkillNames(names, {
+      patterns: ["api-[^s]kill"],
+      matchMode: cliTesting.SkillMatchMode.Glob,
+    }),
+  ).toEqual(new Set(["api-tkill"]));
+});
+
+test("resolveSelectedSkillNames glob mode supports a leading ] inside a character class", () => {
+  const names = ["a]c", "abc", "axc"];
+  const matched = cliTesting.resolveSelectedSkillNames(names, {
+    patterns: ["a[]b]c"],
+    matchMode: cliTesting.SkillMatchMode.Glob,
+  });
+  expect(matched).toEqual(new Set(["a]c", "abc"]));
+});
+
+test("resolveSelectedSkillNames glob mode treats an unterminated [ literally", () => {
+  const names = ["api-[skill", "api-skill"];
+  const matched = cliTesting.resolveSelectedSkillNames(names, {
+    patterns: ["api-[skill"],
+    matchMode: cliTesting.SkillMatchMode.Glob,
+  });
+  expect(matched).toEqual(new Set(["api-[skill"]));
+});
+
 test("resolveSelectedSkillNames glob mode is case-insensitive and full match", () => {
   const names = ["api-skill", "api-tool", "other-skill"];
   expect(
@@ -1949,6 +2008,52 @@ test("CLI install --discover-glob zero matches falls back to the full picker", a
 
   expect(capturedNames.sort()).toEqual(["api-skill (top-pkg)", "other-skill (top-pkg)"]);
   expect(log).toHaveBeenCalledWith("No skills selected.");
+});
+
+test("CLI default command rejects combining --discover-glob and --discover-regex", async () => {
+  const project = writeGlobTestProject(["api-skill"]);
+  process.chdir(project);
+  const { log } = mockConsole();
+
+  await createProgram().parseAsync([
+    "node",
+    "library-skills",
+    "--skill",
+    "api-*",
+    "--discover-glob",
+    "--discover-regex",
+  ]);
+
+  expect(process.exitCode).toBe(1);
+  expect(
+    log.mock.calls.some(([message]) =>
+      String(message).includes("cannot be used together"),
+    ),
+  ).toBe(true);
+  process.exitCode = undefined;
+});
+
+test("CLI default command rejects an invalid --discover-regex pattern", async () => {
+  const project = writeGlobTestProject(["api-skill"]);
+  process.chdir(project);
+  const { log } = mockConsole();
+
+  await createProgram().parseAsync([
+    "node",
+    "library-skills",
+    "--skill",
+    "(",
+    "--discover-regex",
+    "--yes",
+  ]);
+
+  expect(process.exitCode).toBe(1);
+  expect(
+    log.mock.calls.some(([message]) =>
+      String(message).includes("Invalid regular expression"),
+    ),
+  ).toBe(true);
+  process.exitCode = undefined;
 });
 
 test("CLI default command --discover-glob installs all matches with --yes", async () => {


### PR DESCRIPTION
Hey there, greetings from Bavaria ;)

Disclaimer: Code was generated by Sonnet 5, reviewed by GPT 5.5.
Happy to discuss about the changes and adapt.

## Add glob/regex pattern matching to `--skill`

### Why

`--skill`/`-s` only accepted exact skill names, so installing a group of related skills (e.g. everything a package bundles under a common prefix) required listing every name individually or falling back to the interactive picker over the entire discovered skill set. This made it hard to script installs for larger skill sets or apply a naming-convention-based filter.

### How

Two new mutually-exclusive boolean flags change how `--skill` values are interpreted, without altering the default (exact-match) behavior:

- `--discover-glob` — treat `--skill` values as shell-style glob patterns (`*`, `?`, `[seq]`), e.g. `--skill 'api-*' --discover-glob`
- `--discover-regex` — treat `--skill` values as regular expressions, e.g. `--skill '^api-.*$' --discover-regex`

Matching is case-insensitive and requires a full match against the skill name (not a substring search), to avoid surprising partial matches. Passing both flags together is a usage error.

Behavior once patterns are resolved:
- With `--yes`: all matched skills install directly, no prompt (same as today's exact-match `--yes` behavior).
- Without `--yes`: the existing interactive checkbox picker is shown, but scoped to only the matched skills, with all of them pre-checked (uncheck to narrow down).
- If a pattern matches nothing, the command falls back to the full interactive picker over all discovered skills, so a typo doesn't silently no-op.

Supported on both the root/default command and the `install` subcommand — the same places `--skill` already worked. `remove` is unchanged (it uses positional args, not `--skill`).

Internally, the match mode is represented as an enum (`SkillMatchMode` in Python and TypeScript) rather than raw strings, to make the three states explicit and to avoid typo-prone string literals in comparisons and function signatures.

Implemented in parallel in both the Python (`src/library_skills/cli.py`) and TypeScript (`ts/src/cli.ts`) CLIs, which mirror each other's behavior 1:1.

### Testing

- 17 new Python tests and 15 new TypeScript tests cover: glob/regex matching semantics (case-insensitivity, full-match requirement), collision handling, `--yes` vs. interactive precheck flows, zero-match fallback, mutual-exclusivity and invalid-regex errors, and both the root command and `install` subcommand.
- Full existing test suites pass with no new regressions (pre-existing, unrelated Windows symlink-permission failures in the sandbox are unchanged before/after).

### Docs

- `docs/reference.md` updated with the two new flags under the root command and `install` command.
- Both `tool_skill/SKILL.md` files (Python and TS packages) updated so agents relying on Library Skills' own tool-skill guidance know about `--discover-glob`/`--discover-regex`.