### PR TITLE
✨ Add --force flag to overwrite non-symlink installs

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -81,6 +81,7 @@ library-skills install [OPTIONS]
 * `--all`: Install all newly discovered unmanaged skills
 * `-s, --skill TEXT`: Install a specific discovered skill by name
 * `--copy`: Copy files instead of creating symlinks
+* `--force`: Overwrite existing non-symlink files or directories at the destination (useful with --copy on systems without symlink support)
 * `--help`: Show this message and exit.
 
 ## `library-skills remove`

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -47,6 +47,8 @@ Only use `--copy` if your system doesn't support symbolic links (e.g. could happ
 
 By default, it will create symbolic links, which means that if you update the library, its skills will be automatically updated.
 
+If a target directory already has a hand-authored, non-symlink copy of a skill (common when re-running `--copy` on a system without symlink support), installs are skipped to avoid clobbering it. Pass `--force` alongside `--copy` to overwrite it.
+
 ///
 
 ## Committing Installed Skills

--- a/src/library_skills/cli.py
+++ b/src/library_skills/cli.py
@@ -689,12 +689,13 @@ def _install_selected(
     targets: list[InstallTarget],
     project_root: Path,
     copy: bool = False,
+    force: bool = False,
 ) -> int:
     installed_count = 0
     for target in targets:
         for skill in skills:
             try:
-                dest = install_skill(skill, target.path, copy=copy)
+                dest = install_skill(skill, target.path, copy=copy, force=force)
             except InstallError as e:
                 ui.print_skipped(skill.name, str(e), console=console)
                 continue
@@ -766,6 +767,7 @@ def _sync(
     include_all: bool,
     selected_names: list[str],
     copy: bool,
+    force: bool,
     tool_skill: bool | None,
 ) -> None:
     context = _get_project_context()
@@ -887,6 +889,7 @@ def _sync(
             targets=targets,
             project_root=context.project_root,
             copy=copy,
+            force=force,
         )
         ui.print_line(console=console)
         ui.print_summary({"installed skill targets": installed_count}, console=console)
@@ -947,6 +950,16 @@ def callback(
     copy: Annotated[
         bool, typer.Option("--copy", help="Copy files instead of creating symlinks")
     ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help=(
+                "Overwrite existing non-symlink files or directories at the "
+                "destination (useful with --copy on systems without symlink support)"
+            ),
+        ),
+    ] = False,
     tool_skill: Annotated[
         bool | None,
         typer.Option(
@@ -964,6 +977,7 @@ def callback(
             include_all=include_all,
             selected_names=selected_names or [],
             copy=copy,
+            force=force,
             tool_skill=tool_skill,
         )
 
@@ -1080,6 +1094,16 @@ def install(
     copy: Annotated[
         bool, typer.Option("--copy", help="Copy files instead of creating symlinks")
     ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help=(
+                "Overwrite existing non-symlink files or directories at the "
+                "destination (useful with --copy on systems without symlink support)"
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Install skills from installed packages."""
     context = _get_project_context()
@@ -1113,7 +1137,11 @@ def install(
         return
 
     installed_count = _install_selected(
-        skills=selected, targets=targets, project_root=context.project_root, copy=copy
+        skills=selected,
+        targets=targets,
+        project_root=context.project_root,
+        copy=copy,
+        force=force,
     )
     ui.print_line(console=console)
     ui.print_summary({"installed skill targets": installed_count}, console=console)

--- a/src/library_skills/installer.py
+++ b/src/library_skills/installer.py
@@ -116,8 +116,14 @@ def install_skill(
     target_dir: Path,
     *,
     copy: bool = False,
+    force: bool = False,
 ) -> Path:
     """Install a single skill to the target directory.
+
+    By default, existing non-symlink files or directories at the destination
+    block the install. Pass ``force=True`` to overwrite them instead (useful
+    on platforms such as Windows where symlinks are frequently unavailable,
+    forcing ``--copy`` installs that would otherwise be skipped every run).
 
     Returns the path to the installed skill directory.
     """
@@ -125,12 +131,21 @@ def install_skill(
     source = skill.skill_dir.resolve()
 
     if dest.exists() or dest.is_symlink():
+        if not dest.is_symlink() and dest.resolve() == source:
+            # Destination already *is* the skill source (e.g. dogfeeding a
+            # skill from within its own package tree). Overwriting it would
+            # destroy the very files we're about to copy from.
+            return dest
         if dest.is_symlink():
             dest.unlink()
         elif dest.is_file():
-            raise InstallError(f"Cannot overwrite non-symlink file: {dest}")
+            if not force:
+                raise InstallError(f"Cannot overwrite non-symlink file: {dest}")
+            dest.unlink()
         elif dest.is_dir():
-            raise InstallError(f"Cannot overwrite non-symlink directory: {dest}")
+            if not force:
+                raise InstallError(f"Cannot overwrite non-symlink directory: {dest}")
+            shutil.rmtree(dest)
 
     dest.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1078,6 +1078,32 @@ def test_install_all_copy_mode_installs_to_agents_and_claude(tmp_path, monkeypat
     assert not claude_skill.is_symlink()
 
 
+def test_install_copy_force_overwrites_blocking_directory(tmp_path, monkeypatch):
+    project = write_project(tmp_path, dependencies=["demo-pkg>=1"])
+    site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
+    write_distribution_skill(
+        site_packages,
+        dist_name="demo-pkg",
+        package_dir="demo_pkg",
+        skill_name="demo-skill",
+    )
+    blocking = project / ".agents" / "skills" / "demo-skill"
+    blocking.mkdir(parents=True)
+    (blocking / "stale.txt").write_text("stale", encoding="utf-8")
+    monkeypatch.chdir(project)
+
+    blocked = runner.invoke(app, ["install", "--all", "--yes", "--copy"])
+    assert blocked.exit_code == 0
+    assert (blocking / "stale.txt").exists()
+
+    result = runner.invoke(app, ["install", "--all", "--yes", "--copy", "--force"])
+
+    assert result.exit_code == 0
+    assert blocking.is_dir()
+    assert (blocking / "SKILL.md").is_file()
+    assert not (blocking / "stale.txt").exists()
+
+
 def test_install_interactive_can_choose_claude_only(tmp_path, monkeypatch):
     project = write_project(tmp_path, dependencies=["demo-pkg>=1"])
     site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
@@ -1753,6 +1779,26 @@ def test_install_selected_continues_after_install_error(tmp_path):
         cli._install_selected(skills=[skill], targets=[target], project_root=tmp_path)
         == 0
     )
+
+
+def test_install_selected_force_overwrites_blocking_directory(tmp_path):
+    skill = make_cli_skill(tmp_path)
+    target = cli.InstallTarget("universal", tmp_path / ".agents" / "skills")
+    blocking = target.path / skill.name
+    blocking.mkdir(parents=True)
+    (blocking / "stale.txt").write_text("stale", encoding="utf-8")
+
+    installed_count = cli._install_selected(
+        skills=[skill],
+        targets=[target],
+        project_root=tmp_path,
+        copy=True,
+        force=True,
+    )
+
+    assert installed_count == 1
+    assert (blocking / "SKILL.md").is_file()
+    assert not (blocking / "stale.txt").exists()
 
 
 def test_display_path_prefers_project_relative_paths(tmp_path):

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -162,6 +162,64 @@ def test_install_skill_refuses_to_overwrite_non_symlink_file(tmp_path):
         install_skill(skill, target_dir)
 
 
+def test_install_skill_force_overwrites_non_symlink_directory(tmp_path):
+    skill = make_skill(tmp_path)
+    target_dir = tmp_path / ".agents" / "skills"
+    stale = target_dir / skill.name
+    stale.mkdir(parents=True)
+    (stale / "stale.txt").write_text("stale", encoding="utf-8")
+
+    installed_path = install_skill(skill, target_dir, copy=True, force=True)
+
+    assert installed_path.is_dir()
+    assert not installed_path.is_symlink()
+    assert (installed_path / "SKILL.md").is_file()
+    assert not (installed_path / "stale.txt").exists()
+
+
+def test_install_skill_force_overwrites_non_symlink_file(tmp_path):
+    skill = make_skill(tmp_path)
+    target_dir = tmp_path / ".agents" / "skills"
+    target_dir.mkdir(parents=True)
+    (target_dir / skill.name).write_text("not managed", encoding="utf-8")
+
+    installed_path = install_skill(skill, target_dir, copy=True, force=True)
+
+    assert installed_path.is_dir()
+    assert (installed_path / "SKILL.md").is_file()
+
+
+def test_install_skill_force_does_not_delete_source_when_dest_is_source(tmp_path):
+    """A skill whose source dir *is* the destination must not be destroyed.
+
+    This can happen when a package's skill directory is discovered directly
+    inside the target install directory (e.g. dogfeeding within the project's
+    own .agents/skills tree).
+    """
+    target_dir = tmp_path / ".agents" / "skills"
+    target_dir.mkdir(parents=True)
+    skill_dir = target_dir / "demo-skill"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: demo-skill\ndescription: Demo skill.\n---\n", encoding="utf-8"
+    )
+    skill = Skill(
+        name="demo-skill",
+        description="Demo skill.",
+        path=skill_md,
+        package_name="demo-package",
+        package_version="1.0.0",
+        skill_dir=skill_dir,
+    )
+
+    installed_path = install_skill(skill, target_dir, copy=True, force=True)
+
+    assert installed_path == skill_dir
+    assert skill_dir.is_dir()
+    assert (skill_dir / "SKILL.md").is_file()
+
+
 def test_install_skill_replaces_existing_symlink(tmp_path):
     skill = make_skill(tmp_path)
     target_dir = tmp_path / ".agents" / "skills"

--- a/ts/src/cli.ts
+++ b/ts/src/cli.ts
@@ -87,6 +87,7 @@ interface GlobalOptions {
 	all?: boolean;
 	skill?: string[];
 	copy?: boolean;
+	force?: boolean;
 	toolSkill?: boolean;
 }
 
@@ -96,6 +97,7 @@ interface InstallOptions {
 	all?: boolean;
 	skill?: string[];
 	copy?: boolean;
+	force?: boolean;
 }
 
 interface ListOptions {
@@ -708,17 +710,19 @@ function installSelected({
 	targets,
 	projectRoot,
 	copy = false,
+	force = false,
 }: {
 	skills: Skill[];
 	targets: InstallTarget[];
 	projectRoot: string;
 	copy?: boolean;
+	force?: boolean;
 }): number {
 	let installedCount = 0;
 	for (const target of targets) {
 		for (const skill of skills) {
 			try {
-				const dest = installSkill(skill, target.path, { copy });
+				const dest = installSkill(skill, target.path, { copy, force });
 				output.printResult({
 					action: copy ? "Copied" : "Installed",
 					name: skill.name,
@@ -943,6 +947,7 @@ async function sync(options: GlobalOptions): Promise<void> {
 			targets,
 			projectRoot: context.projectRoot,
 			copy: options.copy,
+			force: options.force,
 		});
 		output.printLine();
 		output.printSummary({ "installed skill targets": installedCount });
@@ -1094,6 +1099,7 @@ async function installCommand(options: InstallOptions): Promise<void> {
 		targets,
 		projectRoot: context.projectRoot,
 		copy: options.copy,
+		force: options.force,
 	});
 	output.printLine();
 	output.printSummary({ "installed skill targets": installedCount });
@@ -1151,6 +1157,10 @@ export function createProgram(): Command {
 		.option("--check", "Validate only; exit 1 if installs drift")
 		.option("--all", "Install all newly discovered unmanaged skills")
 		.option("--copy", "Copy files instead of creating symlinks")
+		.option(
+			"--force",
+			"Overwrite existing non-symlink files or directories at the destination",
+		)
 		.option("--tool-skill", "Copy the Library Skills tool skill into the project")
 		.option("--no-tool-skill", "Skip Library Skills tool skill management")
 		.option(
@@ -1199,6 +1209,10 @@ export function createProgram(): Command {
 			[],
 		)
 		.option("--copy", "Copy files instead of creating symlinks")
+		.option(
+			"--force",
+			"Overwrite existing non-symlink files or directories at the destination",
+		)
 		.action(async (options: InstallOptions) => {
 			await installCommand(options);
 		});

--- a/ts/src/installer.ts
+++ b/ts/src/installer.ts
@@ -106,18 +106,30 @@ export function getExistingTargetDirs(
 export function installSkill(
   skill: Skill,
   targetDir: string,
-  options: { copy?: boolean } = {},
+  options: { copy?: boolean; force?: boolean } = {},
 ): string {
   const dest = join(targetDir, skill.name);
   const source = resolve(skill.skillDir);
 
   if (existsSync(dest) || isSymlink(dest)) {
+    if (!isSymlink(dest) && resolve(dest) === source) {
+      // Destination already *is* the skill source (e.g. dogfeeding a skill
+      // from within its own package tree). Overwriting it would destroy the
+      // very files we're about to copy from.
+      return dest;
+    }
     if (isSymlink(dest)) {
       unlinkSync(dest);
     } else if (lstatSync(dest).isFile()) {
-      throw new InstallError(`Cannot overwrite non-symlink file: ${dest}`);
+      if (!options.force) {
+        throw new InstallError(`Cannot overwrite non-symlink file: ${dest}`);
+      }
+      unlinkSync(dest);
     } else if (lstatSync(dest).isDirectory()) {
-      throw new InstallError(`Cannot overwrite non-symlink directory: ${dest}`);
+      if (!options.force) {
+        throw new InstallError(`Cannot overwrite non-symlink directory: ${dest}`);
+      }
+      rmSync(dest, { recursive: true, force: true });
     }
   }
 

--- a/ts/tests/library-skills.test.ts
+++ b/ts/tests/library-skills.test.ts
@@ -1029,6 +1029,39 @@ describe("installer", () => {
     expect(installerTesting.isDirectory(join(root, "missing"))).toBe(false);
   });
 
+  test("force overwrites non-symlink files/directories but not the skill source itself", () => {
+    const root = tempDir();
+    const source = writeSkill(join(root, "source", "agent"), "agent", "Agent skill.");
+    const targetDir = join(root, ".agents", "skills");
+    const skill = makeSkill({ name: "agent", skillDir: source });
+
+    mkdirSync(targetDir, { recursive: true });
+    const staleDir = join(targetDir, "agent");
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(join(staleDir, "stale.txt"), "stale");
+    expect(() => installSkill(skill, targetDir, { copy: true })).toThrow(
+      "Cannot overwrite non-symlink directory",
+    );
+
+    const installed = installSkill(skill, targetDir, { copy: true, force: true });
+    expect(readFileSync(join(installed, "SKILL.md"), "utf8")).toContain("Agent skill.");
+    expect(existsSync(join(installed, "stale.txt"))).toBe(false);
+
+    rmSync(installed, { recursive: true, force: true });
+    writeFileSync(installed, "not managed");
+    const reinstalled = installSkill(skill, targetDir, { copy: true, force: true });
+    expect(lstatSync(reinstalled).isDirectory()).toBe(true);
+
+    // A skill whose source directory *is* the destination must not be deleted.
+    const selfTargetDir = join(root, "self-target");
+    const selfSkillDir = join(selfTargetDir, "self-skill");
+    writeSkill(selfSkillDir, "self-skill", "Self skill.");
+    const selfSkill = makeSkill({ name: "self-skill", skillDir: selfSkillDir });
+    const untouched = installSkill(selfSkill, selfTargetDir, { copy: true, force: true });
+    expect(untouched).toBe(selfSkillDir);
+    expect(readFileSync(join(selfSkillDir, "SKILL.md"), "utf8")).toContain("Self skill.");
+  });
+
   test("copies, updates, and protects the Library Skills tool skill", () => {
     const root = tempDir();
     const targetDir = join(root, ".agents", "skills");


### PR DESCRIPTION
Hey there, greetings from Bavaria ;)

Disclaimer: Code was generated by Sonnet 5, reviewed by GPT 5.5.
Happy to discuss about the changes and adapt.

## Add `--force` flag to overwrite non-symlink installs

### Why

On systems without symbolic link support — most notably Windows without Developer Mode or elevated permissions — `library-skills install`/sync must run with `--copy`. However, once a skill has been copy-installed, every subsequent run silently **skips** it, because the installer refuses to overwrite an existing non-symlink directory/file at the destination (by design, to avoid clobbering hand-authored content).

This means Windows users can never pick up updates to a skill via `--copy` without first manually deleting the stale copy — defeating the purpose of `--all`/re-sync workflows, e.g.:

```
uvx library-skills install --copy --all
Skipped: myskill: Cannot overwrite non-symlink directory: ...
```

### What

- Added a `--force` flag to both the `install` command and the default sync command, in **both** the Python (`uvx`) CLI and the parallel npm/TypeScript CLI, so behavior stays consistent across ecosystems.
- `install_skill()` / `installSkill()` now accept a `force` option: when set, existing non-symlink files or directories at the destination are removed before installing, instead of raising `InstallError`. Without `--force`, behavior is unchanged (still skipped with an error, protecting hand-authored content by default).
- Added a safety guard: if a skill's own source directory happens to resolve to the same path as the install destination (e.g. a skill discovered from within its own `.agents/skills` tree), `--force` will no longer delete it — it's a no-op instead of self-destructing the source. (Caught during review.)
- Updated `docs/reference.md` and `docs/use/index.md` to document the new flag and when to use it.
- Added regression tests in both the Python and TypeScript test suites covering: forced overwrite of a blocking file, forced overwrite of a blocking directory, and the source == destination safety guard.

### Usage

```
uvx library-skills install --copy --force --all
```

### Testing

- `pytest tests/test_installer.py tests/test_cli.py` — all new tests pass; pre-existing failures are unrelated (sandbox lacks Windows symlink privilege, same failures exist on `main`).
- `vitest run` (TS suite) — same result: new tests pass, no new failures vs. baseline.