### PR TITLE
feat: Introduce FrameworkConfig for multi-agent target management

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ Then it will ask where to install new skills and add them as symbolic links, so 
 
 The symlinks are relative, so projects with stable repo-local installs can commit them to Git. They may be broken before dependencies are installed, then resolve after setup. On Windows, real symlink checkout can require Developer Mode or elevated permissions; use `--copy` if symlinks are not practical.
 
-By default it selects `.agents/skills`, the agent-neutral target. If the project already has a `.claude/` directory, it selects `.claude/skills` too.
+By default it selects `.agents/skills`, the agent-neutral target. If the project already has a `.claude/` directory, it selects `.claude/skills` too. Similarly, if the project has a `.kiro/` directory, it selects `.kiro/skills` too.
 
 /// tip
 
-If you are using Claude Code, select `.claude/skills` when asked for installation targets, as Claude Code doesn't support the standard `.agents` directory. For non-interactive installs, add the `--claude` CLI option to install the skills in `.claude/skills` too.
+* If you are using Claude Code, select `.claude/skills` when asked for installation targets. For non-interactive installs, add the `--claude` CLI option to install the skills in `.claude/skills` too.
+* If you are using Kiro, select `.kiro/skills` when asked for installation targets. For non-interactive installs, add the `--kiro` CLI option to install the skills in `.kiro/skills` too.
 
 ///
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,11 +62,12 @@ Then it will ask where to install new skills and add them as symbolic links, so 
 
 The symlinks are relative, so projects with stable repo-local installs can commit them to Git. They may be broken before dependencies are installed, then resolve after setup. On Windows, real symlink checkout can require Developer Mode or elevated permissions; use `--copy` if symlinks are not practical.
 
-By default it selects `.agents/skills`, the agent-neutral target. If the project already has a `.claude/` directory, it selects `.claude/skills` too.
+By default it selects `.agents/skills`, the agent-neutral target. If the project already has a `.claude/` directory, it selects `.claude/skills` too. Similarly, if the project has a `.kiro/` directory, it selects `.kiro/skills` too.
 
 /// tip
 
-If you are using Claude Code, select `.claude/skills` when asked for installation targets, as Claude Code doesn't support the standard `.agents` directory. For non-interactive installs, add the `--claude` CLI option to install the skills in `.claude/skills` too.
+* If you are using Claude Code, select `.claude/skills` when asked for installation targets. For non-interactive installs, add the `--claude` CLI option to install the skills in `.claude/skills` too.
+* If you are using Kiro, select `.kiro/skills` when asked for installation targets. For non-interactive installs, add the `--kiro` CLI option to install the skills in `.kiro/skills` too.
 
 ///
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -15,6 +15,7 @@ library-skills [OPTIONS] COMMAND [ARGS]...
 **Options**:
 
 * `--claude`: Also install/manage skills in .claude/skills/ alongside .agents/skills/
+* `--kiro`: Also install/manage skills in .kiro/skills/ alongside .agents/skills/
 * `-y, --yes`: Skip confirmation prompts and reconcile managed symlink drift
 * `--check`: Validate only; exit 1 if installs drift
 * `--all`: Install all newly discovered unmanaged skills
@@ -61,6 +62,7 @@ library-skills list [OPTIONS]
 * `--installed`: Only show installed skills
 * `--json`: Output as JSON
 * `--claude`: Also include .claude/skills/ alongside .agents/skills/
+* `--kiro`: Also include .kiro/skills/ alongside .agents/skills/
 * `--all`: Include skills from transitive dependencies
 * `--help`: Show this message and exit.
 
@@ -77,6 +79,7 @@ library-skills install [OPTIONS]
 **Options**:
 
 * `--claude`: Also install skills in .claude/skills/ alongside .agents/skills/
+* `--kiro`: Also install skills in .kiro/skills/ alongside .agents/skills/
 * `-y, --yes`: Skip interactive selection
 * `--all`: Install all newly discovered unmanaged skills
 * `-s, --skill TEXT`: Install a specific discovered skill by name
@@ -100,5 +103,6 @@ library-skills remove [OPTIONS] [SKILL_NAMES]...
 **Options**:
 
 * `--claude`: Also remove from .claude/skills/ alongside .agents/skills/
+* `--kiro`: Also remove from .kiro/skills/ alongside .agents/skills/
 * `-y, --yes`: Skip interactive selection
 * `--help`: Show this message and exit.

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -192,6 +192,30 @@ npx library-skills --claude
 
 ////
 
+### Kiro
+
+If you are using Kiro, it uses the `.kiro` directory.
+
+When Library Skills asks for installation targets, select `.kiro/skills`.
+
+For non-interactive installs, use `--kiro` to install in `.kiro/skills` too.
+
+//// tab | Python uvx
+
+```bash
+uvx library-skills --kiro
+```
+
+////
+
+//// tab | Node.js npx
+
+```bash
+npx library-skills --kiro
+```
+
+////
+
 ## Other Installations
 
 The <abbr title="Command Line Interface">CLI</abbr> program `library-skills` is designed to make it work with `uvx` or `npx`.

--- a/src/library_skills/cli.py
+++ b/src/library_skills/cli.py
@@ -931,6 +931,13 @@ def callback(
             help="Also install/manage skills in .claude/skills/ alongside .agents/skills/",
         ),
     ] = False,
+    include_kiro: Annotated[
+        bool,
+        typer.Option(
+            "--kiro",
+            help="Also install/manage skills in .kiro/skills/ alongside .agents/skills/",
+        ),
+    ] = False,
     yes: Annotated[
         bool, typer.Option("--yes", "-y", help="Skip confirmation prompts")
     ] = False,
@@ -960,8 +967,13 @@ def callback(
 ) -> None:
     """Discover and reconcile agent skills from installed library packages."""
     if ctx.invoked_subcommand is None:
+        enabled_frameworks = set()
+        if include_claude:
+            enabled_frameworks.add("claude")
+        if include_kiro:
+            enabled_frameworks.add("kiro")
         _sync(
-            include_claude=include_claude,
+            enabled_frameworks=enabled_frameworks,
             yes=yes,
             check=check,
             include_all=include_all,
@@ -1013,6 +1025,13 @@ def list_cmd(
             help="Also include .claude/skills/ alongside .agents/skills/",
         ),
     ] = False,
+    include_kiro: Annotated[
+        bool,
+        typer.Option(
+            "--kiro",
+            help="Also include .kiro/skills/ alongside .agents/skills/",
+        ),
+    ] = False,
     include_all: Annotated[
         bool,
         typer.Option("--all", help="Include skills from transitive dependencies"),
@@ -1026,8 +1045,13 @@ def list_cmd(
         skills=result.skills,
         include_all=include_all,
     )
+    enabled_frameworks = set()
+    if include_claude:
+        enabled_frameworks.add("claude")
+    if include_kiro:
+        enabled_frameworks.add("kiro")
     targets = get_existing_target_dirs(
-        context.project_root, include_claude=include_claude
+        context.project_root, enabled_frameworks=enabled_frameworks
     )
     statuses = _installed_statuses(targets=targets, skills=result.skills)
 
@@ -1065,6 +1089,13 @@ def install(
         typer.Option(
             "--claude",
             help="Also install skills in .claude/skills/ alongside .agents/skills/",
+        ),
+    ] = False,
+    include_kiro: Annotated[
+        bool,
+        typer.Option(
+            "--kiro",
+            help="Also install skills in .kiro/skills/ alongside .agents/skills/",
         ),
     ] = False,
     yes: Annotated[
@@ -1106,10 +1137,16 @@ def install(
         ui.print_message("No skills selected.", console=console)
         return
 
+    enabled_frameworks = set()
+    if include_claude:
+        enabled_frameworks.add("claude")
+    if include_kiro:
+        enabled_frameworks.add("kiro")
+
     targets = _select_install_targets(
         project_root=context.project_root,
-        include_claude=include_claude,
-        interactive=not yes and not include_claude,
+        enabled_frameworks=enabled_frameworks,
+        interactive=not yes and not enabled_frameworks,
     )
     if not targets:
         ui.print_message("No installation targets selected.", console=console)
@@ -1134,6 +1171,13 @@ def remove(
             help="Also remove from .claude/skills/ alongside .agents/skills/",
         ),
     ] = False,
+    include_kiro: Annotated[
+        bool,
+        typer.Option(
+            "--kiro",
+            help="Also remove from .kiro/skills/ alongside .agents/skills/",
+        ),
+    ] = False,
     yes: Annotated[
         bool, typer.Option("--yes", "-y", help="Skip interactive selection")
     ] = False,
@@ -1141,8 +1185,13 @@ def remove(
     """Remove installed symlinked skills."""
     context = _get_project_context()
     result = _scan_context(context)
+    enabled_frameworks = set()
+    if include_claude:
+        enabled_frameworks.add("claude")
+    if include_kiro:
+        enabled_frameworks.add("kiro")
     targets = get_existing_target_dirs(
-        context.project_root, include_claude=include_claude
+        context.project_root, enabled_frameworks=enabled_frameworks
     )
     statuses = _installed_statuses(targets=targets, skills=result.skills)
 

--- a/src/library_skills/cli.py
+++ b/src/library_skills/cli.py
@@ -15,6 +15,7 @@ from .deps import (
     get_workspace_top_level_deps,
 )
 from .installer import (
+    FRAMEWORKS,
     TOOL_SKILL_MARKER,
     TOOL_SKILL_NAME,
     InstallError,
@@ -172,16 +173,18 @@ def _display_path(path: Path | None, project_root: Path) -> str:
 def _target_prompt_name(target: InstallTarget) -> str:
     if target.name == "universal":
         return "Agents (.agents/skills)"
-    if target.name == "claude-compatible":
-        return "Claude Code (.claude/skills)"
+    for fw in FRAMEWORKS.values():
+        if target.name == fw.name:
+            return fw.display_name
     return target.name
 
 
 def _target_short_name(target: InstallTarget) -> str:
     if target.name == "universal":
         return "Agents"
-    if target.name == "claude-compatible":
-        return "Claude Code"
+    for fw in FRAMEWORKS.values():
+        if target.name == fw.name:
+            return fw.short_name
     return target.name
 
 
@@ -372,11 +375,11 @@ def _select_targets_interactive(
 def _select_install_targets(
     *,
     project_root: Path,
-    include_claude: bool,
+    enabled_frameworks: set[str],
     interactive: bool,
 ) -> list[InstallTarget]:
     if not interactive:
-        return get_target_dirs(project_root, include_claude=include_claude)
+        return get_target_dirs(project_root, enabled_frameworks=enabled_frameworks)
     return _select_targets_interactive(
         project_root=project_root,
         default_targets=get_default_install_target_dirs(project_root),
@@ -583,14 +586,14 @@ def _select_installed_skills_interactive(
 
 
 def _sync_target_dirs(
-    *, project_root: Path, include_claude: bool, yes: bool, check: bool
+    *, project_root: Path, enabled_frameworks: set[str], yes: bool, check: bool
 ) -> list[InstallTarget]:
     targets_by_name = {
         target.name: target for target in get_existing_target_dirs(project_root)
     }
     default_targets = (
-        get_target_dirs(project_root, include_claude=include_claude)
-        if yes or check or include_claude
+        get_target_dirs(project_root, enabled_frameworks=enabled_frameworks)
+        if yes or check or enabled_frameworks
         else get_default_install_target_dirs(project_root)
     )
     for target in default_targets:
@@ -760,7 +763,7 @@ def _tool_skill_is_missing(targets: list[InstallTarget]) -> bool:
 
 def _sync(
     *,
-    include_claude: bool,
+    enabled_frameworks: set[str],
     yes: bool,
     check: bool,
     include_all: bool,
@@ -772,7 +775,7 @@ def _sync(
     result = _scan_context(context)
     targets = _sync_target_dirs(
         project_root=context.project_root,
-        include_claude=include_claude,
+        enabled_frameworks=enabled_frameworks,
         yes=yes,
         check=check,
     )
@@ -816,7 +819,7 @@ def _sync(
             ui.print_line(console=console)
             _, tool_failed = _sync_tool_skill(
                 targets=get_target_dirs(
-                    context.project_root, include_claude=include_claude
+                    context.project_root, enabled_frameworks=enabled_frameworks
                 ),
                 project_root=context.project_root,
                 check=True,
@@ -875,8 +878,8 @@ def _sync(
     if selected:
         targets = _select_install_targets(
             project_root=context.project_root,
-            include_claude=include_claude,
-            interactive=not yes and not include_claude,
+            enabled_frameworks=enabled_frameworks,
+            interactive=not yes and not enabled_frameworks,
         )
         if not targets:
             ui.print_message("No installation targets selected.", console=console)

--- a/src/library_skills/installer.py
+++ b/src/library_skills/installer.py
@@ -74,28 +74,39 @@ class ToolSkillStatus:
 
 
 def get_target_dirs(
-    project_root: Path, *, include_claude: bool = False
+    project_root: Path,
+    *,
+    include_claude: bool = False,
+    include_kiro: bool = False,
+    enabled_frameworks: set[str] | None = None,
 ) -> list[InstallTarget]:
     """Get project-level target directories.
 
-    The universal .agents/skills target is always included. Claude-compatible
+    The universal .agents/skills target is always included. Framework-compatible
     installs are additional and never replace the universal target.
     """
     targets = [
         InstallTarget(name="universal", path=project_root / UNIVERSAL_SKILLS_DIR)
     ]
+    
+    fw_keys = set(enabled_frameworks) if enabled_frameworks else set()
     if include_claude:
-        targets.append(
-            InstallTarget(
-                name="claude-compatible", path=project_root / CLAUDE_SKILLS_DIR
+        fw_keys.add("claude")
+    if include_kiro:
+        fw_keys.add("kiro")
+
+    for key in sorted(fw_keys):
+        if key in FRAMEWORKS:
+            fw = FRAMEWORKS[key]
+            targets.append(
+                InstallTarget(name=fw.name, path=project_root / fw.skills_dir)
             )
-        )
     return targets
 
 
 def get_all_target_dirs(project_root: Path) -> list[InstallTarget]:
     """Get all supported project-level target directories."""
-    return get_target_dirs(project_root, include_claude=True)
+    return get_target_dirs(project_root, enabled_frameworks=set(FRAMEWORKS.keys()))
 
 
 def get_default_install_target_dirs(project_root: Path) -> list[InstallTarget]:
@@ -110,8 +121,10 @@ def get_default_install_target_dirs(project_root: Path) -> list[InstallTarget]:
 
     if (project_root / ".agents").exists():
         selected.append(by_name["universal"])
-    if (project_root / ".claude").exists():
-        selected.append(by_name["claude-compatible"])
+    
+    for fw in FRAMEWORKS.values():
+        if (project_root / fw.detector_dir).exists():
+            selected.append(by_name[fw.name])
 
     if not selected:
         selected.append(by_name["universal"])
@@ -119,16 +132,26 @@ def get_default_install_target_dirs(project_root: Path) -> list[InstallTarget]:
 
 
 def get_existing_target_dirs(
-    project_root: Path, *, include_claude: bool = False
+    project_root: Path,
+    *,
+    include_claude: bool = False,
+    include_kiro: bool = False,
+    enabled_frameworks: set[str] | None = None,
 ) -> list[InstallTarget]:
     """Get targets to inspect for existing installed skills.
 
-    Without explicit Claude compatibility, this only returns concrete skills
-    directories that already exist. With include_claude, preserve the legacy
-    explicit behavior of managing both known targets.
+    Without explicit compatibility options, this only returns concrete skills
+    directories that already exist. With options, preserve the explicit behavior
+    of managing those specific targets.
     """
+    fw_keys = set(enabled_frameworks) if enabled_frameworks else set()
     if include_claude:
-        return get_target_dirs(project_root, include_claude=True)
+        fw_keys.add("claude")
+    if include_kiro:
+        fw_keys.add("kiro")
+
+    if fw_keys:
+        return get_target_dirs(project_root, enabled_frameworks=fw_keys)
     return [
         target for target in get_all_target_dirs(project_root) if target.path.is_dir()
     ]
@@ -281,8 +304,10 @@ def install_tool_skill(target_dir: Path) -> Path:
 
 
 def _target_for_path(target_dir: Path) -> InstallTarget:
-    if target_dir.as_posix().endswith(CLAUDE_SKILLS_DIR):
-        return InstallTarget(name="claude-compatible", path=target_dir)
+    posix_path = target_dir.as_posix()
+    for fw in FRAMEWORKS.values():
+        if posix_path.endswith(fw.skills_dir):
+            return InstallTarget(name=fw.name, path=target_dir)
     return InstallTarget(name="universal", path=target_dir)
 
 

--- a/src/library_skills/installer.py
+++ b/src/library_skills/installer.py
@@ -9,9 +9,40 @@ from .scanner import Skill
 
 UNIVERSAL_SKILLS_DIR = ".agents/skills"
 CLAUDE_SKILLS_DIR = ".claude/skills"
+KIRO_SKILLS_DIR = ".kiro/skills"
 TOOL_SKILL_NAME = "library-skills"
 TOOL_SKILL_MARKER = ".library-skills.json"
 TOOL_SKILL_KIND = "tool-skill"
+
+
+@dataclass(frozen=True)
+class FrameworkConfig:
+    name: str
+    display_name: str
+    short_name: str
+    skills_dir: str
+    detector_dir: str
+    cli_flag: str
+
+
+FRAMEWORKS = {
+    "claude": FrameworkConfig(
+        name="claude-compatible",
+        display_name="Claude Code (.claude/skills)",
+        short_name="Claude Code",
+        skills_dir=".claude/skills",
+        detector_dir=".claude",
+        cli_flag="--claude",
+    ),
+    "kiro": FrameworkConfig(
+        name="kiro-compatible",
+        display_name="Kiro (.kiro/skills)",
+        short_name="Kiro",
+        skills_dir=".kiro/skills",
+        detector_dir=".kiro",
+        cli_flag="--kiro",
+    ),
+}
 
 
 @dataclass(frozen=True)

--- a/src/library_skills/installer.py
+++ b/src/library_skills/installer.py
@@ -7,9 +7,9 @@ from pathlib import Path
 
 from .scanner import Skill
 
-UNIVERSAL_SKILLS_DIR = ".agents/skills"
-CLAUDE_SKILLS_DIR = ".claude/skills"
-KIRO_SKILLS_DIR = ".kiro/skills"
+UNIVERSAL_SKILLS_DIR = Path(".agents/skills")
+CLAUDE_SKILLS_DIR = Path(".claude/skills")
+KIRO_SKILLS_DIR = Path(".kiro/skills")
 TOOL_SKILL_NAME = "library-skills"
 TOOL_SKILL_MARKER = ".library-skills.json"
 TOOL_SKILL_KIND = "tool-skill"
@@ -20,8 +20,8 @@ class FrameworkConfig:
     name: str
     display_name: str
     short_name: str
-    skills_dir: str
-    detector_dir: str
+    skills_dir: Path
+    detector_dir: Path
     cli_flag: str
 
 
@@ -30,16 +30,16 @@ FRAMEWORKS = {
         name="claude-compatible",
         display_name="Claude Code (.claude/skills)",
         short_name="Claude Code",
-        skills_dir=".claude/skills",
-        detector_dir=".claude",
+        skills_dir=Path(".claude/skills"),
+        detector_dir=Path(".claude"),
         cli_flag="--claude",
     ),
     "kiro": FrameworkConfig(
         name="kiro-compatible",
         display_name="Kiro (.kiro/skills)",
         short_name="Kiro",
-        skills_dir=".kiro/skills",
-        detector_dir=".kiro",
+        skills_dir=Path(".kiro/skills"),
+        detector_dir=Path(".kiro"),
         cli_flag="--kiro",
     ),
 }
@@ -306,7 +306,7 @@ def install_tool_skill(target_dir: Path) -> Path:
 def _target_for_path(target_dir: Path) -> InstallTarget:
     posix_path = target_dir.as_posix()
     for fw in FRAMEWORKS.values():
-        if posix_path.endswith(fw.skills_dir):
+        if posix_path.endswith(fw.skills_dir.as_posix()):
             return InstallTarget(name=fw.name, path=target_dir)
     return InstallTarget(name="universal", path=target_dir)
 

--- a/src/library_skills/tool_skill/SKILL.md
+++ b/src/library_skills/tool_skill/SKILL.md
@@ -27,6 +27,7 @@ Agents bundle their own skills by including an `.agents/skills` directory. More 
 - Run `uvx library-skills --check` or `npx library-skills --check` to validate managed skill symlink state without changing files.
 - Run `uvx library-skills --yes` or `npx library-skills --yes` to repair stale managed symlinks and remove orphaned managed symlinks non-interactively.
 - Add `--claude` when `.claude/skills` should also be managed.
+- Add `--kiro` when `.kiro/skills` should also be managed.
 - Add `--skill NAME` to install a specific discovered skill by name.
 
 ## Safety

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1689,6 +1689,7 @@ def test_select_targets_interactive_preselects_defaults(monkeypatch, tmp_path):
             assert [option["name"] for option in options] == [
                 "Agents (.agents/skills)",
                 "Claude Code (.claude/skills)",
+                "Kiro (.kiro/skills)",
             ]
             self.options = options
             self.checked = set()
@@ -1772,13 +1773,16 @@ def test_display_path_prefers_project_relative_paths(tmp_path):
 def test_target_prompt_labels_are_user_facing(tmp_path):
     agents = cli.InstallTarget("universal", tmp_path / ".agents" / "skills")
     claude = cli.InstallTarget("claude-compatible", tmp_path / ".claude" / "skills")
+    kiro = cli.InstallTarget("kiro-compatible", tmp_path / ".kiro" / "skills")
     custom = cli.InstallTarget("custom", tmp_path / "custom")
 
     assert cli._target_prompt_name(agents) == "Agents (.agents/skills)"
     assert cli._target_prompt_name(claude) == "Claude Code (.claude/skills)"
+    assert cli._target_prompt_name(kiro) == "Kiro (.kiro/skills)"
     assert cli._target_prompt_name(custom) == "custom"
     assert cli._target_short_name(agents) == "Agents"
     assert cli._target_short_name(claude) == "Claude Code"
+    assert cli._target_short_name(kiro) == "Kiro"
     assert cli._target_short_name(custom) == "custom"
 
 
@@ -1802,3 +1806,60 @@ def test_main_invokes_typer_app():
         cli.main()
 
     assert called == [True]
+
+
+def test_yes_repairs_existing_kiro_target_without_kiro_flag(tmp_path, monkeypatch):
+    project = write_project(tmp_path, dependencies=["demo-pkg>=1"])
+    site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
+    repaired_skill = write_distribution_skill(
+        site_packages,
+        dist_name="demo-pkg",
+        package_dir="demo_pkg",
+        skill_name="demo-skill",
+    )
+    kiro_dir = project / ".kiro" / "skills"
+    kiro_dir.mkdir(parents=True)
+    installed = kiro_dir / "demo-skill"
+    installed.symlink_to(project / "missing-target", target_is_directory=True)
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["--yes"])
+
+    assert result.exit_code == 0
+    assert "kiro-compatible" in result.output
+    assert installed.is_symlink()
+    assert installed.resolve() == repaired_skill.resolve()
+
+
+def test_check_tool_skill_reports_missing_default_and_kiro_targets(tmp_path, monkeypatch):
+    project = write_project(tmp_path, dependencies=[])
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["--check", "--tool-skill", "--kiro"])
+
+    assert result.exit_code == 1
+    assert "tool skill: missing" in result.output
+    assert str(Path(".agents") / "skills" / "library-skills") in result.output
+    assert str(Path(".kiro") / "skills" / "library-skills") in result.output
+
+
+def test_install_all_copy_mode_installs_to_agents_and_kiro(tmp_path, monkeypatch):
+    project = write_project(tmp_path, dependencies=["demo-pkg>=1"])
+    site_packages = project / ".venv" / "lib" / "python3.12" / "site-packages"
+    write_distribution_skill(
+        site_packages,
+        dist_name="demo-pkg",
+        package_dir="demo_pkg",
+        skill_name="demo-skill",
+    )
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["install", "--all", "--yes", "--copy", "--kiro"])
+
+    agents_skill = project / ".agents" / "skills" / "demo-skill"
+    kiro_skill = project / ".kiro" / "skills" / "demo-skill"
+    assert result.exit_code == 0
+    assert agents_skill.is_dir()
+    assert not agents_skill.is_symlink()
+    assert kiro_skill.is_dir()
+    assert not kiro_skill.is_symlink()

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -5,6 +5,7 @@ import pytest
 import library_skills.installer as installer
 from library_skills.installer import (
     CLAUDE_SKILLS_DIR,
+    KIRO_SKILLS_DIR,
     TOOL_SKILL_KIND,
     TOOL_SKILL_MARKER,
     TOOL_SKILL_NAME,
@@ -44,17 +45,18 @@ def make_skill(tmp_path: Path, name: str = "demo-skill") -> Skill:
     )
 
 
-def test_get_target_dirs_always_includes_agents_and_optionally_claude(tmp_path):
+def test_get_target_dirs_always_includes_agents_and_optionally_claude_or_kiro(tmp_path):
     default_targets = get_target_dirs(tmp_path)
     assert len(default_targets) == 1
     assert default_targets[0].name == "universal"
     assert default_targets[0].path == tmp_path / UNIVERSAL_SKILLS_DIR
 
-    targets = get_target_dirs(tmp_path, include_claude=True)
+    targets = get_target_dirs(tmp_path, include_claude=True, include_kiro=True)
 
-    assert [target.name for target in targets] == ["universal", "claude-compatible"]
+    assert [target.name for target in targets] == ["universal", "claude-compatible", "kiro-compatible"]
     assert targets[0].path == tmp_path / UNIVERSAL_SKILLS_DIR
     assert targets[1].path == tmp_path / CLAUDE_SKILLS_DIR
+    assert targets[2].path == tmp_path / KIRO_SKILLS_DIR
 
 
 def test_default_install_target_dirs_follow_project_state(tmp_path):
@@ -74,32 +76,41 @@ def test_default_install_target_dirs_follow_project_state(tmp_path):
         target.name for target in get_default_install_target_dirs(claude_project)
     ] == ["claude-compatible"]
 
-    both_project = tmp_path / "both-project"
-    (both_project / ".agents").mkdir(parents=True)
-    (both_project / ".claude").mkdir(parents=True)
+    kiro_project = tmp_path / "kiro-project"
+    (kiro_project / ".kiro").mkdir(parents=True)
     assert [
-        target.name for target in get_default_install_target_dirs(both_project)
+        target.name for target in get_default_install_target_dirs(kiro_project)
+    ] == ["kiro-compatible"]
+
+    all_project = tmp_path / "all-project"
+    (all_project / ".agents").mkdir(parents=True)
+    (all_project / ".claude").mkdir(parents=True)
+    (all_project / ".kiro").mkdir(parents=True)
+    assert [
+        target.name for target in get_default_install_target_dirs(all_project)
     ] == [
         "universal",
         "claude-compatible",
+        "kiro-compatible",
     ]
 
 
 def test_existing_target_dirs_only_include_concrete_skills_dirs(tmp_path):
     (tmp_path / ".agents").mkdir()
     (tmp_path / ".claude").mkdir()
+    (tmp_path / ".kiro").mkdir()
 
     assert get_existing_target_dirs(tmp_path) == []
 
-    (tmp_path / ".claude" / "skills").mkdir()
+    (tmp_path / ".kiro" / "skills").mkdir()
 
     assert [target.name for target in get_existing_target_dirs(tmp_path)] == [
-        "claude-compatible"
+        "kiro-compatible"
     ]
     assert [
         target.name
-        for target in get_existing_target_dirs(tmp_path, include_claude=True)
-    ] == ["universal", "claude-compatible"]
+        for target in get_existing_target_dirs(tmp_path, include_kiro=True)
+    ] == ["universal", "kiro-compatible"]
 
 
 def test_install_skill_creates_symlink_and_list_installed_skills_reports_it(tmp_path):

--- a/ts/src/cli.ts
+++ b/ts/src/cli.ts
@@ -83,6 +83,7 @@ interface InstalledStatus {
 
 interface GlobalOptions {
 	claude?: boolean;
+	kiro?: boolean;
 	yes?: boolean;
 	check?: boolean;
 	all?: boolean;
@@ -93,6 +94,7 @@ interface GlobalOptions {
 
 interface InstallOptions {
 	claude?: boolean;
+	kiro?: boolean;
 	yes?: boolean;
 	all?: boolean;
 	skill?: string[];
@@ -103,6 +105,7 @@ interface ListOptions {
 	installed?: boolean;
 	json?: boolean;
 	claude?: boolean;
+	kiro?: boolean;
 	all?: boolean;
 }
 
@@ -1032,6 +1035,7 @@ function listCommand(options: ListOptions): void {
 	});
 	const targets = getExistingTargetDirs(context.projectRoot, {
 		includeClaude: options.claude,
+		includeKiro: options.kiro,
 	});
 	const statuses = installedStatuses({ targets, skills: result.skills });
 
@@ -1094,7 +1098,8 @@ async function installCommand(options: InstallOptions): Promise<void> {
 	const targets = await selectInstallTargets({
 		projectRoot: context.projectRoot,
 		includeClaude: options.claude,
-		interactive: !options.yes && !options.claude,
+		includeKiro: options.kiro,
+		interactive: !options.yes && !options.claude && !options.kiro,
 	});
 	if (targets.length === 0) {
 		output.printMessage("No installation targets selected.");
@@ -1113,12 +1118,13 @@ async function installCommand(options: InstallOptions): Promise<void> {
 
 async function removeCommand(
 	skillNames: string[],
-	options: { claude?: boolean; yes?: boolean },
+	options: { claude?: boolean; kiro?: boolean; yes?: boolean },
 ): Promise<void> {
 	const context = getProjectContext();
 	const result = scanContext(context);
 	const targets = getExistingTargetDirs(context.projectRoot, {
 		includeClaude: options.claude,
+		includeKiro: options.kiro,
 	});
 	const statuses = installedStatuses({ targets, skills: result.skills });
 
@@ -1159,6 +1165,7 @@ export function createProgram(): Command {
 			"Discover and reconcile agent skills from installed library packages.",
 		)
 		.option("--claude", "Also manage .claude/skills alongside .agents/skills")
+		.option("--kiro", "Also manage .kiro/skills alongside .agents/skills")
 		.option("-y, --yes", "Skip confirmation prompts")
 		.option("--check", "Validate only; exit 1 if installs drift")
 		.option("--all", "Install all newly discovered unmanaged skills")
@@ -1190,6 +1197,7 @@ export function createProgram(): Command {
 		.option("--installed", "Only show installed skills")
 		.option("--json", "Output as JSON")
 		.option("--claude", "Also include .claude/skills alongside .agents/skills")
+		.option("--kiro", "Also include .kiro/skills alongside .agents/skills")
 		.option("--all", "Include skills from transitive dependencies")
 		.action((options: ListOptions) => {
 			listCommand(options);
@@ -1201,6 +1209,10 @@ export function createProgram(): Command {
 		.option(
 			"--claude",
 			"Also install in .claude/skills alongside .agents/skills",
+		)
+		.option(
+			"--kiro",
+			"Also install in .kiro/skills alongside .agents/skills",
 		)
 		.option("-y, --yes", "Skip interactive selection")
 		.option("--all", "Install all newly discovered unmanaged skills")
@@ -1223,11 +1235,15 @@ export function createProgram(): Command {
 			"--claude",
 			"Also remove from .claude/skills alongside .agents/skills",
 		)
+		.option(
+			"--kiro",
+			"Also remove from .kiro/skills alongside .agents/skills",
+		)
 		.option("-y, --yes", "Skip interactive selection")
 		.action(
 			async (
 				skillNames: string[],
-				options: { claude?: boolean; yes?: boolean },
+				options: { claude?: boolean; kiro?: boolean; yes?: boolean },
 			) => {
 				await removeCommand(skillNames, options);
 			},

--- a/ts/src/cli.ts
+++ b/ts/src/cli.ts
@@ -11,6 +11,7 @@ import {
 	getWorkspaceTopLevelDeps,
 } from "./deps.js";
 import {
+	FRAMEWORKS,
 	getAllTargetDirs,
 	getDefaultInstallTargetDirs,
 	getExistingTargetDirs,
@@ -241,8 +242,10 @@ function targetPromptName(target: InstallTarget): string {
 	if (target.name === "universal") {
 		return "Agents (.agents/skills)";
 	}
-	if (target.name === "claude-compatible") {
-		return "Claude Code (.claude/skills)";
+	for (const fw of Object.values(FRAMEWORKS)) {
+		if (target.name === fw.name) {
+			return fw.displayName;
+		}
 	}
 	return target.name;
 }
@@ -251,8 +254,10 @@ function targetShortName(target: InstallTarget): string {
 	if (target.name === "universal") {
 		return "Agents";
 	}
-	if (target.name === "claude-compatible") {
-		return "Claude Code";
+	for (const fw of Object.values(FRAMEWORKS)) {
+		if (target.name === fw.name) {
+			return fw.shortName;
+		}
 	}
 	return target.name;
 }
@@ -552,14 +557,16 @@ async function selectTargetsInteractive({
 async function selectInstallTargets({
 	projectRoot,
 	includeClaude,
+	includeKiro,
 	interactive,
 }: {
 	projectRoot: string;
 	includeClaude?: boolean;
+	includeKiro?: boolean;
 	interactive: boolean;
 }): Promise<InstallTarget[]> {
 	if (!interactive) {
-		return getTargetDirs(projectRoot, { includeClaude });
+		return getTargetDirs(projectRoot, { includeClaude, includeKiro });
 	}
 	return selectTargetsInteractive({
 		projectRoot,
@@ -601,11 +608,13 @@ async function selectInstalledSkillsInteractive(
 function syncTargetDirs({
 	projectRoot,
 	includeClaude,
+	includeKiro,
 	yes,
 	check,
 }: {
 	projectRoot: string;
 	includeClaude?: boolean;
+	includeKiro?: boolean;
 	yes?: boolean;
 	check?: boolean;
 }): InstallTarget[] {
@@ -613,8 +622,8 @@ function syncTargetDirs({
 		getExistingTargetDirs(projectRoot).map((target) => [target.name, target]),
 	);
 	const defaultTargets =
-		yes || check || includeClaude
-			? getTargetDirs(projectRoot, { includeClaude })
+		yes || check || includeClaude || includeKiro
+			? getTargetDirs(projectRoot, { includeClaude, includeKiro })
 			: getDefaultInstallTargetDirs(projectRoot);
 	for (const target of defaultTargets) {
 		targetsByName.set(target.name, target);
@@ -822,6 +831,7 @@ async function sync(options: GlobalOptions): Promise<void> {
 	let targets = syncTargetDirs({
 		projectRoot: context.projectRoot,
 		includeClaude: options.claude,
+		includeKiro: options.kiro,
 		yes: options.yes,
 		check: options.check,
 	});
@@ -867,6 +877,7 @@ async function sync(options: GlobalOptions): Promise<void> {
 			const toolResult = syncToolSkill({
 				targets: getTargetDirs(context.projectRoot, {
 					includeClaude: options.claude,
+					includeKiro: options.kiro,
 				}),
 				projectRoot: context.projectRoot,
 				check: true,
@@ -931,7 +942,8 @@ async function sync(options: GlobalOptions): Promise<void> {
 		targets = await selectInstallTargets({
 			projectRoot: context.projectRoot,
 			includeClaude: options.claude,
-			interactive: !options.yes && !options.claude,
+			includeKiro: options.kiro,
+			interactive: !options.yes && !options.claude && !options.kiro,
 		});
 		if (targets.length === 0) {
 			output.printMessage("No installation targets selected.");

--- a/ts/src/installer.ts
+++ b/ts/src/installer.ts
@@ -90,44 +90,55 @@ export class ToolSkillError extends Error {
 
 export function getTargetDirs(
   projectRoot: string,
-  options: { includeClaude?: boolean } = {},
+  options: { includeClaude?: boolean; includeKiro?: boolean } = {},
 ): InstallTarget[] {
   const targets: InstallTarget[] = [
     { name: "universal", path: join(projectRoot, UNIVERSAL_SKILLS_DIR) },
   ];
   if (options.includeClaude) {
     targets.push({
-      name: "claude-compatible",
-      path: join(projectRoot, CLAUDE_SKILLS_DIR),
+      name: FRAMEWORKS.claude.name,
+      path: join(projectRoot, FRAMEWORKS.claude.skillsDir),
+    });
+  }
+  if (options.includeKiro) {
+    targets.push({
+      name: FRAMEWORKS.kiro.name,
+      path: join(projectRoot, FRAMEWORKS.kiro.skillsDir),
     });
   }
   return targets;
 }
 
 export function getAllTargetDirs(projectRoot: string): InstallTarget[] {
-  return getTargetDirs(projectRoot, { includeClaude: true });
+  return getTargetDirs(projectRoot, { includeClaude: true, includeKiro: true });
 }
 
 export function getDefaultInstallTargetDirs(projectRoot: string): InstallTarget[] {
-  const [universal, claude] = getAllTargetDirs(projectRoot);
-
+  const targets = getAllTargetDirs(projectRoot);
+  const byName = new Map(targets.map((target) => [target.name, target]));
   const selected: InstallTarget[] = [];
+
   if (existsSync(join(projectRoot, ".agents"))) {
-    selected.push(universal);
+    const universal = byName.get("universal");
+    if (universal) selected.push(universal);
   }
-  if (existsSync(join(projectRoot, ".claude"))) {
-    selected.push(claude);
+  for (const fw of Object.values(FRAMEWORKS)) {
+    if (existsSync(join(projectRoot, fw.detectorDir))) {
+      const target = byName.get(fw.name);
+      if (target) selected.push(target);
+    }
   }
 
-  return selected.length > 0 ? selected : [universal];
+  return selected.length > 0 ? selected : [byName.get("universal")!];
 }
 
 export function getExistingTargetDirs(
   projectRoot: string,
-  options: { includeClaude?: boolean } = {},
+  options: { includeClaude?: boolean; includeKiro?: boolean } = {},
 ): InstallTarget[] {
-  if (options.includeClaude) {
-    return getTargetDirs(projectRoot, { includeClaude: true });
+  if (options.includeClaude || options.includeKiro) {
+    return getTargetDirs(projectRoot, options);
   }
   return getAllTargetDirs(projectRoot).filter((target) => isDirectory(target.path));
 }
@@ -274,9 +285,12 @@ export function listInstalledSkills(targetDir: string): InstalledSkill[] {
 }
 
 function targetForPath(targetDir: string): InstallTarget {
-  return targetDir.endsWith(CLAUDE_SKILLS_DIR)
-    ? { name: "claude-compatible", path: targetDir }
-    : { name: "universal", path: targetDir };
+  for (const fw of Object.values(FRAMEWORKS)) {
+    if (targetDir.endsWith(fw.skillsDir)) {
+      return { name: fw.name, path: targetDir };
+    }
+  }
+  return { name: "universal", path: targetDir };
 }
 
 function isManagedToolSkillMarker(marker: string): boolean {

--- a/ts/src/installer.ts
+++ b/ts/src/installer.ts
@@ -17,9 +17,38 @@ import type { Skill } from "./scanner.js";
 
 export const UNIVERSAL_SKILLS_DIR = ".agents/skills";
 export const CLAUDE_SKILLS_DIR = ".claude/skills";
+export const KIRO_SKILLS_DIR = ".kiro/skills";
 export const TOOL_SKILL_NAME = "library-skills";
 export const TOOL_SKILL_MARKER = ".library-skills.json";
 export const TOOL_SKILL_KIND = "tool-skill";
+
+export interface FrameworkConfig {
+  name: string;
+  displayName: string;
+  shortName: string;
+  skillsDir: string;
+  detectorDir: string;
+  cliFlag: string;
+}
+
+export const FRAMEWORKS: Record<string, FrameworkConfig> = {
+  claude: {
+    name: "claude-compatible",
+    displayName: "Claude Code (.claude/skills)",
+    shortName: "Claude Code",
+    skillsDir: ".claude/skills",
+    detectorDir: ".claude",
+    cliFlag: "--claude",
+  },
+  kiro: {
+    name: "kiro-compatible",
+    displayName: "Kiro (.kiro/skills)",
+    shortName: "Kiro",
+    skillsDir: ".kiro/skills",
+    detectorDir: ".kiro",
+    cliFlag: "--kiro",
+  },
+};
 
 export interface InstallTarget {
   name: string;

--- a/ts/src/tool_skill/SKILL.md
+++ b/ts/src/tool_skill/SKILL.md
@@ -27,6 +27,7 @@ Agents bundle their own skills by including an `.agents/skills` directory. More 
 - Run `uvx library-skills --check` or `npx library-skills --check` to validate managed skill symlink state without changing files.
 - Run `uvx library-skills --yes` or `npx library-skills --yes` to repair stale managed symlinks and remove orphaned managed symlinks non-interactively.
 - Add `--claude` when `.claude/skills` should also be managed.
+- Add `--kiro` when `.kiro/skills` should also be managed.
 - Add `--skill NAME` to install a specific discovered skill by name.
 
 ## Safety

--- a/ts/tests/library-skills.test.ts
+++ b/ts/tests/library-skills.test.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   readFileSync,
   readlinkSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   unlinkSync,
@@ -974,9 +975,10 @@ describe("installer", () => {
     const targetDir = join(root, ".agents", "skills");
     const skill = makeSkill({ name: "agent", skillDir: source });
 
-    expect(getTargetDirs(root, { includeClaude: true })).toEqual([
+    expect(getTargetDirs(root, { includeClaude: true, includeKiro: true })).toEqual([
       { name: "universal", path: join(root, ".agents", "skills") },
       { name: "claude-compatible", path: join(root, ".claude", "skills") },
+      { name: "kiro-compatible", path: join(root, ".kiro", "skills") },
     ]);
     expect(getDefaultInstallTargetDirs(root)).toEqual([
       { name: "universal", path: join(root, ".agents", "skills") },
@@ -985,10 +987,16 @@ describe("installer", () => {
     expect(getDefaultInstallTargetDirs(root)).toEqual([
       { name: "claude-compatible", path: join(root, ".claude", "skills") },
     ]);
+    mkdirSync(join(root, ".kiro"), { recursive: true });
+    expect(getDefaultInstallTargetDirs(root)).toEqual([
+      { name: "claude-compatible", path: join(root, ".claude", "skills") },
+      { name: "kiro-compatible", path: join(root, ".kiro", "skills") },
+    ]);
     mkdirSync(join(root, ".agents"), { recursive: true });
     expect(getDefaultInstallTargetDirs(root)).toEqual([
       { name: "universal", path: join(root, ".agents", "skills") },
       { name: "claude-compatible", path: join(root, ".claude", "skills") },
+      { name: "kiro-compatible", path: join(root, ".kiro", "skills") },
     ]);
     rmSync(join(root, ".agents"), { recursive: true, force: true });
     expect(getExistingTargetDirs(root)).toEqual([]);
@@ -996,9 +1004,10 @@ describe("installer", () => {
     expect(getExistingTargetDirs(root)).toEqual([
       { name: "claude-compatible", path: join(root, ".claude", "skills") },
     ]);
-    expect(getExistingTargetDirs(root, { includeClaude: true })).toEqual([
+    expect(getExistingTargetDirs(root, { includeClaude: true, includeKiro: true })).toEqual([
       { name: "universal", path: join(root, ".agents", "skills") },
       { name: "claude-compatible", path: join(root, ".claude", "skills") },
+      { name: "kiro-compatible", path: join(root, ".kiro", "skills") },
     ]);
 
     const copied = installSkill(skill, targetDir, { copy: true });
@@ -1640,6 +1649,12 @@ test("CLI helpers filter skills and classify installed statuses", () => {
   ).toBe("Claude Code (.claude/skills)");
   expect(
     cliTesting.targetPromptName({
+      name: "kiro-compatible",
+      path: join(root, ".kiro", "skills"),
+    }),
+  ).toBe("Kiro (.kiro/skills)");
+  expect(
+    cliTesting.targetPromptName({
       name: "custom",
       path: join(root, "custom"),
     }),
@@ -1656,6 +1671,12 @@ test("CLI helpers filter skills and classify installed statuses", () => {
       path: join(root, ".claude", "skills"),
     }),
   ).toBe("Claude Code");
+  expect(
+    cliTesting.targetShortName({
+      name: "kiro-compatible",
+      path: join(root, ".kiro", "skills"),
+    }),
+  ).toBe("Kiro");
   expect(
     cliTesting.targetShortName({
       name: "custom",
@@ -1915,6 +1936,7 @@ test("CLI interactive install can choose Claude targets", async () => {
       expect(prompt.choices.map((choice) => choice.name)).toEqual([
         "Agents (.agents/skills)",
         "Claude Code (.claude/skills)",
+        "Kiro (.kiro/skills)",
       ]);
       expect(prompt.validate?.([])).toBe(
         "Please select at least one installation target.",
@@ -2232,7 +2254,7 @@ test("CLI sync deduplicates new skills across selected targets", async () => {
 });
 
 function tempDir(): string {
-  const directory = mkdtempSync(join(tmpdir(), "library-skills-ts-"));
+  const directory = realpathSync(mkdtempSync(join(tmpdir(), "library-skills-ts-")));
   tempDirs.push(directory);
   return directory;
 }
@@ -2499,3 +2521,38 @@ function lstatExists(path: string): boolean {
     return false;
   }
 }
+
+test("CLI sync with --kiro installs skills to kiro target", async () => {
+  const project = writeProjectWithTopLevelAndTransitiveSkills();
+  process.chdir(project);
+
+  await cliTesting.sync({ all: true, yes: true, kiro: true, toolSkill: false });
+
+  expect(lstatSync(join(project, ".agents", "skills", "top-skill")).isSymbolicLink()).toBe(true);
+  expect(lstatSync(join(project, ".kiro", "skills", "top-skill")).isSymbolicLink()).toBe(true);
+});
+
+test("CLI sync auto-detects .kiro directory and installs skills there", async () => {
+  const project = writeProjectWithTopLevelAndTransitiveSkills();
+  process.chdir(project);
+  mkdirSync(join(project, ".kiro"));
+
+  vi.mocked(checkbox)
+    .mockImplementationOnce(async (prompt) => {
+      return [prompt.choices[0].value];
+    })
+    .mockImplementationOnce(async (prompt) => {
+      // Prompt selection for installation targets
+      expect(prompt.choices.map((choice) => choice.name)).toEqual([
+        "Agents (.agents/skills)",
+        "Claude Code (.claude/skills)",
+        "Kiro (.kiro/skills)",
+      ]);
+      return [prompt.choices[2].value];
+    });
+
+  await cliTesting.sync({ toolSkill: false });
+
+  expect(lstatSync(join(project, ".kiro", "skills", "top-skill")).isSymbolicLink()).toBe(true);
+  expect(existsSync(join(project, ".agents", "skills", "top-skill"))).toBe(false);
+});


### PR DESCRIPTION
Discussion:
- https://github.com/tiangolo/library-skills/discussions/175

## Description

This PR adds support for **Kiro** skills and generalizes the AI framework installation target resolution across both the Python and JS/TS codebases.

### Changes:
1. **Framework Registry**: Introduced a generic `FRAMEWORKS` configuration registry in both Python (`installer.py`) and TypeScript (`installer.ts`). This allows scaling support to additional AI coding assistants/frameworks in the future simply by adding them to the registry configuration.
2. **Kiro Skill Support**: Adds `.kiro/skills` as a target directory and registers the `--kiro` flag in both the Python and TypeScript CLIs.
3. **Target Auto-Detection**: Interactively prompts users to target Kiro if a `.kiro` directory exists in the project root.
4. **Verification & Tests**: Added unit tests to `tests/test_installer.py`, `tests/test_cli.py`, and `ts/tests/library-skills.test.ts` to cover Kiro target paths, CLI option inputs, and auto-detection.
5. **Documentation**: Updated CLI reference lists, README, and use guides (`docs/`) to document the `--kiro` option.

## AI Disclaimer

This PR was generated using Google Gemini models via the Antigravity AI coding assistant.

<details>
<summary>AI transcript</summary>

### **User**:

I want to add support for "kiro" skills to this library.
This should be essentially the same pattern as "claude" (this skills just go inside a different directory.

But before we do this we need to write a minimal Github Issue for this.
The issue should talk about what supporting "kiro" means and possibly the best way to extend this support and make it easier to support additional ai frameworks.

I will be creating the actual issue.

---

### **AI Assistant**:

Here is a draft for the GitHub Issue. It covers what supporting "kiro" means, identifies the current hardcoded pattern, and proposes an elegant registry-based refactor to make adding future AI coding assistants and frameworks straightforward.

***

# GitHub Issue Draft

## Title
feat: Add support for "kiro" skills and generalize AI framework installation targets

## Description
Currently, `library-skills` supports installing skills to the universal agent-neutral directory (`.agents/skills`) and optionally to a Claude Code compatible directory (`.claude/skills`). 

We want to add support for a new AI framework called **Kiro**, which requires installing skills under a different directory target: `.kiro/skills`. 

Rather than repeating the existing pattern by adding more hardcoded flags (`--kiro`, `include_kiro`, etc.) throughout the Python and TypeScript codebases, we should refactor target resolution to use a generic **Framework Registry**. This will make it trivial to support additional AI frameworks in the future.

---

### What Supporting "kiro" Means

1. **Target Directory**: Supporting skill installation into `.kiro/skills`.
2. **CLI Flag**: Providing a new `--kiro` flag in both the Python and JS/TS CLIs (alongside `--claude`).
3. **Auto-Detection**: If a `.kiro` directory exists in the project root, the interactive prompt should default to include `kiro-compatible` as an installation target.
4. **Tool Skill Management**: Checking, installing, and repairing the `library-skills` tool skill template within `.kiro/skills`.

---

### Proposed Architecture for Extensibility

Instead of propagating boolean variables like `include_claude` or `includeClaude` through scanner, installer, and CLI functions, we propose introducing a central `FrameworkConfig` registry in both Python and TypeScript.

#### 1. Registry Definition

**Python (`src/library_skills/installer.py`):**
```python
@dataclass(frozen=True)
class FrameworkConfig:
    name: str
    display_name: str
    short_name: str
    skills_dir: str
    detector_dir: string
    cli_flag: string

FRAMEWORKS: dict[str, FrameworkConfig] = {
    "claude": FrameworkConfig(
        name="claude-compatible",
        display_name="Claude Code (.claude/skills)",
        short_name="Claude Code",
        skills_dir=".claude/skills",
        detector_dir=".claude",
        cli_flag="--claude",
    ),
    "kiro": FrameworkConfig(
        name="kiro-compatible",
        display_name="Kiro (.kiro/skills)",
        short_name="Kiro",
        skills_dir=".kiro/skills",
        detector_dir=".kiro",
        cli_flag="--kiro",
    ),
}
```

**TypeScript (`ts/src/installer.ts`):**
```typescript
export interface FrameworkConfig {
  name: string;
  displayName: string;
  shortName: string;
  skillsDir: string;
  detectorDir: string;
  cliFlag: string;
}

export const FRAMEWORKS: Record<string, FrameworkConfig> = {
  claude: {
    name: "claude-compatible",
    displayName: "Claude Code (.claude/skills)",
    shortName: "Claude Code",
    skillsDir: ".claude/skills",
    detectorDir: ".claude",
    cliFlag: "--claude",
  },
  kiro: {
    name: "kiro-compatible",
    displayName: "Kiro (.kiro/skills)",
    shortName: "Kiro",
    skillsDir: ".kiro/skills",
    detectorDir: ".kiro",
    cliFlag: "--kiro",
  },
};
```

#### 2. Generic Target Resolution

Functions like `get_target_dirs` and `get_existing_target_dirs` will accept a set of enabled framework keys (e.g. `{"claude", "kiro"}`) instead of hardcoded keyword arguments:

```python
def get_target_dirs(
    project_root: Path,
    *,
    enabled_frameworks: set[str] | None = None,
) -> list[InstallTarget]:
    targets = [
        InstallTarget(name="universal", path=project_root / UNIVERSAL_SKILLS_DIR)
    ]
    if enabled_frameworks:
        for key in enabled_frameworks:
            if key in FRAMEWORKS:
                fw = FRAMEWORKS[key]
                targets.append(
                    InstallTarget(name=fw.name, path=project_root / fw.skills_dir)
                )
    return targets
```

#### 3. CLI Integration
At the CLI entry points (using `Typer` in Python and `Commander` in TS), we statically declare CLI flags (`--claude` and `--kiro`) and compile them into a set of enabled frameworks to pass down to the business logic:

```python
enabled_frameworks = set()
if include_claude:
    enabled_frameworks.add("claude")
if include_kiro:
    enabled_frameworks.add("kiro")
```

---

### Verification and Test Plan

- **Unit Tests**:
  - Update `tests/test_installer.py` and `ts/tests/library-skills.test.ts` to verify target directory generation and defaults when `.kiro` directories exist.
  - Update CLI tests (`tests/test_cli.py`) to cover the `--kiro` flag.
- **Documentation**:
  - Update usage guides and CLI references to mention the `--kiro` target option.

---

### **User**:

Would this change how a user interacts with library skills?

---

### **AI Assistant**:

No, **for existing users, their interaction remains completely unchanged and backward-compatible.** 

However, the user experience expands in the following ways for Kiro users:

1. **New CLI flag**: Kiro users can specify `--kiro` to target Kiro-compatible installs directly:
   * Python: `uvx library-skills --kiro`
   * JS/TS: `npx library-skills --kiro`

2. **Auto-detection & Interactive Prompts**: If a project contains a `.kiro` folder, running `library-skills` interactively will now detect it and prompt the user with a checkbox option to select `Kiro (.kiro/skills)` as an installation target, exactly as it does for `.claude`.

---

### **User**:

now implement this

---

### **AI Assistant**:

I have created the [implementation_plan.md](file:///Users/gabriel/.gemini/antigravity/brain/1b9af532-5bb8-4b36-a308-199aae62f89a/implementation_plan.md) with the detailed design for both the Python and TypeScript codebases. 

Please review the plan, and click **Proceed** (or let me know) when you are ready for me to begin execution!

---

### **User**:

The user has approved this document.

</details>

## Checklist

- [x] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [x] I added tests for the change.
- [x] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
- [x] The documentation explains the change if needed.
```