### PR TITLE
👷 Fix zizmor checkout version comment

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Description

Update the version comment for the pinned `actions/checkout` commit from `v6` to `v6.0.3`.

The pinned SHA is unchanged. This fixes zizmor's `ref-version-mismatch` finding by making the comment match the tag that points to the commit.

## Checks

- `git diff --check`
- `uvx zizmor .`

## AI Disclaimer

Using Codex with gpt-5.6-sol. Reviewed manually.
