### PR TITLE
⬆️ Upgrade latest-changes to 0.7.1

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -35,11 +35,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true' }}
         with:
           limit-access-to-actor: true
-      - uses: tiangolo/latest-changes@c9b73efbc8992ef1a401e4235ea307a8ca8a724b # 0.6.1
+      - uses: tiangolo/latest-changes@8a940392f4c65274539453a5d5a76d9550203ac1 # 0.7.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          latest_changes_file: docs/release-notes.md
-          latest_changes_header: '## Latest Changes'
-          end_regex: '^## '
           debug_logs: true
-          label_header_prefix: '### '


### PR DESCRIPTION
## Summary

- upgrade `tiangolo/latest-changes` from 0.6.1 to 0.7.1 using the immutable release SHA
- remove redundant release-note path and heading configuration now provided by the action defaults
- preserve explicit nonstandard file configuration where required

## Impact

The workflow now relies on automatic discovery for standard `release-notes.md` layouts and the standalone release-note heading defaults introduced in 0.7.1.

## Validation

- parsed the updated workflow with `yq`
- verified the discovered release-notes target exists
- `git diff --check`
- audited the batch with authenticated online `zizmor`; reported findings were pre-existing and unrelated to this migration

## AI Disclaimer

Using Codex with gpt-5.6-sol. Reviewed manually.