### PR TITLE
✨ Use PR Submit for automated PRs

### DIFF
--- a/.github/pr-submit.yml
+++ b/.github/pr-submit.yml
@@ -1,0 +1,2 @@
+workflows:
+  - .github/workflows/prepare-release.yml

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,9 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
+      id-token: write
     env:
       PREPARE_RELEASE_VERSION_FILE: pyproject.toml
       PREPARE_RELEASE_PACKAGE_JSON_FILE: package.json
@@ -40,8 +39,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          token: ${{ secrets.LATEST_CHANGES }} # zizmor: ignore[secrets-outside-env]
-          persist-credentials: true
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -65,18 +63,22 @@ jobs:
           version="$(uv run python scripts/prepare_release.py current-version)"
           echo "$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Get PR Submit token
+        id: pr-submit
+        uses: tiangolo/pr-submit@d802fdf59bde80bc3eb8bd3259f4cbeec63de4aa # 0.0.1
       - name: Create release pull request
         env:
-          GH_TOKEN: ${{ secrets.LATEST_CHANGES }}
+          GH_TOKEN: ${{ steps.pr-submit.outputs.token }}
           VERSION: ${{ steps.release-version.outputs.version }}
         run: |
           set -euo pipefail
           branch="release-${VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "pr-submit[bot]"
+          git config user.email "pr-submit[bot]@users.noreply.github.com"
           git switch -c "$branch"
           git add "$PREPARE_RELEASE_VERSION_FILE" "$PREPARE_RELEASE_PACKAGE_JSON_FILE" "$PREPARE_RELEASE_PACKAGE_LOCK_FILE" "$PREPARE_RELEASE_RELEASE_NOTES_FILE" uv.lock
           git commit -m "🔖 Release version ${VERSION}"
+          gh auth setup-git
           git push --set-upstream origin "$branch"
           gh pr create \
             --base main \


### PR DESCRIPTION
## Summary

- allow the automated PR workflow to request PR Submit tokens
- replace the long-lived repository secret with a short-lived repository-scoped token obtained through GitHub OIDC
- use read-only checkout credentials and attribute generated commits to `pr-submit[bot]`

## Security

The workflow receives only `contents: read` and `id-token: write`. PR Submit validates the allowlisted workflow from the default branch before returning its short-lived installation token with repository contents and pull-request write permissions.

## Checks

- parsed the workflow and `.github/pr-submit.yml` as YAML
- `git diff --check`

## AI Disclaimer

This PR was created with the help of gpt-5.6-sol and reviewed by hand.
