### PR TITLE
🔧 Set Dependabot schedule interval to "monthly"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 7
     commit-message:
@@ -23,7 +23,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 7
     commit-message:
@@ -58,7 +58,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 7
     commit-message:


### PR DESCRIPTION
Weekly dependency updates are too noisy and are not needed.

This changes all configured ecosystems from weekly to monthly, except for `pre-commit` where present, as that ecosystem is planned for removal separately.

## Checks

- Parsed `.github/dependabot.yml` with `yq`.
- Ran `git diff --check`.

## AI Disclaimer

Using Codex with gpt-5.6-sol. Reviewed manually.
