### PR TITLE
👷 Remove legacy label check

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,9 +5,6 @@ on:
       - opened
       - synchronize
       - reopened
-      # For label-checker
-      - labeled
-      - unlabeled
 
 jobs:
   labeler:
@@ -17,17 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
-      if: ${{ github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     - run: echo "Done adding labels"
-  # Run this after labeler applied labels
-  check-labels:
-    needs:
-      - labeler
-    permissions:
-      pull-requests: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: agilepathway/label-checker@c3d16ad512e7cea5961df85ff2486bb774caf3c5 # v1.6.65
-        with:
-          one_of: breaking,security,feature,bug,refactor,upgrade,docs,lang-all,internal,release
-          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Preserve automatic pull request labeling with `actions/labeler`
- Remove the legacy `agilepathway` label-checker job
- Remove the `labeled` and `unlabeled` triggers that only served the legacy checker

The required `latest-changes/label` GitHub App check now provides label validation without an additional workflow.

## Checks

- `git diff --check`
- `zizmor .github/workflows/labeler.yml`

## AI Disclaimer

Using Codex with gpt-5.6-sol. Reviewed manually.
