### PR TITLE
⬆️ Bump Typer min version to `0.26.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pyyaml>=5.3.1",
     "rich-toolkit>=0.20.1",
     "tomli>=2.4.1 ; python_version < '3.11'",
-    "typer>=0.24.2",
+    "typer>=0.26.1",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -636,7 +636,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.3.1" },
     { name = "rich-toolkit", specifier = ">=0.20.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.4.1" },
-    { name = "typer", specifier = ">=0.24.2" },
+    { name = "typer", specifier = ">=0.26.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Tests in CI are currently failing with uv resolution `lowest-direct`. Bumping min Typer version to 0.26.0 to resolve this

🤖 This pull request was created with the help of AI (Codex).

Checked manually